### PR TITLE
Initial try fixing core.py initialization bug

### DIFF
--- a/pywwt_web/core.py
+++ b/pywwt_web/core.py
@@ -11,12 +11,14 @@ DEFAULT_SURVEYS_URL = 'http://www.worldwidetelescope.org/wwtweb/catalog.aspx?W=s
 
 
 class BaseWWTWidget(HasTraits):
-
+    
     def __init__(self):
-        super(BaseWWTWidget, self).__init__()
+        super(BaseWWTWidget, self).__init__() # does super() alone do the same?
         self.observe(self._on_trait_change, type='change')
         self._available_layers = []
         self.load_image_collection(DEFAULT_SURVEYS_URL)
+        for name in self.trait_names():
+            self._on_trait_change({'name': name, 'new': getattr(self,name), 'type': 'change'})
 
     def _on_trait_change(self, changed):
         # This method gets called anytime a trait gets changed. Since this class
@@ -24,8 +26,10 @@ class BaseWWTWidget(HasTraits):
         # its own, we only want to react to changes in traits that have the wwt
         # metadata attribute (which indicates the name of the corresponding WWT
         # setting).
+        print('accessed')
         wwt_name = self.trait_metadata(changed['name'], 'wwt')
         if wwt_name is not None:
+            print(changed)
             self._send_msg(event='setting_set',
                            setting=wwt_name,
                            value=changed['new'])

--- a/pywwt_web/core.py
+++ b/pywwt_web/core.py
@@ -13,7 +13,7 @@ DEFAULT_SURVEYS_URL = 'http://www.worldwidetelescope.org/wwtweb/catalog.aspx?W=s
 class BaseWWTWidget(HasTraits):
     
     def __init__(self):
-        super(BaseWWTWidget, self).__init__() # does super() alone do the same?
+        super(BaseWWTWidget, self).__init__()
         self.observe(self._on_trait_change, type='change')
         self._available_layers = []
         self.load_image_collection(DEFAULT_SURVEYS_URL)
@@ -26,10 +26,8 @@ class BaseWWTWidget(HasTraits):
         # its own, we only want to react to changes in traits that have the wwt
         # metadata attribute (which indicates the name of the corresponding WWT
         # setting).
-        print('accessed')
         wwt_name = self.trait_metadata(changed['name'], 'wwt')
         if wwt_name is not None:
-            print(changed)
             self._send_msg(event='setting_set',
                            setting=wwt_name,
                            value=changed['new'])


### PR DESCRIPTION
On [line 28](https://github.com/ojustino/pywwt-web/blob/force-traits/pywwt_web/core.py#L28), `_on_trait_change()` calls [WWTQtWidget's `_send_msg()` method from qt_widget.py](https://github.com/ojustino/pywwt-web/blob/force-traits/pywwt_web/qt_widget.py#L140). However, when using the new [`for` loop on line 14](https://github.com/ojustino/pywwt-web/blob/force-traits/pywwt_web/core.py#L15), I get `AttributeError: 'WWTQtWidget' object has no attribute 'widget'`. For some reason it's not accessing the definition for `self.widget` [in the WWTQtWidget class' `__init__()` method from qt_widget.py](https://github.com/ojustino/pywwt-web/blob/force-traits/pywwt_web/qt_widget.py#L125) and I can't figure out why.