### PR TITLE
Added methods to load/control tours [issue #4]

### DIFF
--- a/pywwt/core.py
+++ b/pywwt/core.py
@@ -58,6 +58,16 @@ class BaseWWTWidget(HasTraits):
 
     # TODO: need to add more methods here.
 
+    def load_tour(self,url):
+        # should this throw an error if url doesn't end in '.wwt'?
+        self._send_msg(event='load_tour',url=url)
+
+    def play_tour(self):
+        self._send_msg(event='play_tour')
+
+    def stop_tour(self):
+        self._send_msg(event='stop_tour')
+
     def center_on_coordinates(self, coord, fov, instant=True):
         coord_icrs = coord.icrs
         self._send_msg(event='center_on_coordinates',

--- a/pywwt/core.py
+++ b/pywwt/core.py
@@ -59,7 +59,6 @@ class BaseWWTWidget(HasTraits):
     # TODO: need to add more methods here.
 
     def load_tour(self,url):
-        # should this throw an error if url doesn't end in '.wwt'?
         """
         Load and begin playing a tour based on the URL to a .wtt file from 
         the WorldWideTelescope website.
@@ -69,7 +68,11 @@ class BaseWWTWidget(HasTraits):
         url : str
             The URL of the chosen tour (a .wtt file)
         """
-        self._send_msg(event='load_tour',url=url)
+        # throw error if url doesn't end in .wtt
+        if url[-4:] == '.wtt':
+            self._send_msg(event='load_tour',url=url)
+        else:
+            raise ValueError('url must end in \'.wwt\'')
 
     def stop_tour(self):
         """

--- a/pywwt/core.py
+++ b/pywwt/core.py
@@ -60,13 +60,28 @@ class BaseWWTWidget(HasTraits):
 
     def load_tour(self,url):
         # should this throw an error if url doesn't end in '.wwt'?
+        """
+        Load and begin playing a tour based on the URL to a .wtt file from 
+        the WorldWideTelescope website.
+
+        Parameters
+        ----------
+        url : str
+            The URL of the chosen tour (a .wtt file)
+        """
         self._send_msg(event='load_tour',url=url)
 
-    def play_tour(self):
-        self._send_msg(event='play_tour')
-
     def stop_tour(self):
+        """
+        Stop a loaded tour.
+        """
         self._send_msg(event='stop_tour')
+
+    def play_tour(self):
+        """
+        Play a stopped tour.
+        """
+        self._send_msg(event='play_tour')
 
     def center_on_coordinates(self, coord, fov, instant=True):
         coord_icrs = coord.icrs

--- a/pywwt/imagery.py
+++ b/pywwt/imagery.py
@@ -10,6 +10,11 @@ def get_imagery_layers(url):
     Get the list of available image layers that can be used as background
     or foreground based on the URL to a WTML (WorldWide Telescope image
     collection file).
+
+    Parameters
+    ----------
+    url : str
+        The URL of the chosen layer.
     """
 
     available_layers = OrderedDict()

--- a/pywwt/imagery.py
+++ b/pywwt/imagery.py
@@ -14,7 +14,7 @@ def get_imagery_layers(url):
     Parameters
     ----------
     url : str
-        The URL of the chosen layer.
+        The URL of the image collection.
     """
 
     available_layers = OrderedDict()

--- a/pywwt/static/wwt_json_api.js
+++ b/pywwt/static/wwt_json_api.js
@@ -11,6 +11,18 @@ function wwt_apply_json_message(wwt, msg) {
 
   switch(msg['event']) {
 
+    case 'load_tour':
+      wwt.loadTour(msg['url']);
+      break;
+
+    case 'play_tour':
+      wwt.playTour();
+      break;
+
+    case 'stop_tour':
+      wwt.stopTour();
+      break;
+
     case 'load_image_collection':
       wwt.loadImageCollection(msg['url']);
       break;


### PR DESCRIPTION
I don't know if this is intentional, but `play_tour()` resumes playback immediately while `stop_tour()` slows the tour down to a stop over the course of a few seconds.