### PR TITLE
Making local traits take astropy quants [issue #25]

### DIFF
--- a/pywwt/core.py
+++ b/pywwt/core.py
@@ -107,15 +107,15 @@ class BaseWWTWidget(HasTraits):
             raise TraitError('location_altitude not in units of length')
    
     @validate('location_latitude')
-    def _validate_latiitude(self,proposal):
-        if proposal['value'].unit == u.degree:
+    def _validate_latitude(self,proposal):
+        if proposal['value'].unit.physical_type == 'angle':
             return proposal['value']
         else:
             raise TraitError('location_latitude not in degrees')
 
     @validate('location_longitude')
     def _validate_longitude(self,proposal):
-        if proposal['value'].unit == u.degree:
+        if proposal['value'].unit.physical_type == 'angle':
             return proposal['value']
         else:
             raise TraitError('location_longitude not in degrees')

--- a/pywwt/core.py
+++ b/pywwt/core.py
@@ -2,6 +2,7 @@ from traitlets import Bool, HasTraits, Float, Unicode, Any, observe, validate, T
 from astropy import units as u
 
 from .annotation import Circle, Poly, PolyLine
+from .quantity_trait import AstropyQuantity
 from .imagery import get_imagery_layers
 
 # The WWT web control API is described here:
@@ -96,9 +97,9 @@ class BaseWWTWidget(HasTraits):
                        instant=instant)
 
     local_horizon_mode = Bool(False, help='Whether the view should be that of a local latitude, longitude, and altitude').tag(wwt='localHorizonMode', sync=True)
-    location_altitude  = Any(0, help='Assigns altitude (in meters) for view location').tag(wwt='locationAltitude', sync=True)
-    location_latitude  = Any(47.633, help='Assigns latitude for view location').tag(wwt='locationLat', sync=True)
-    location_longitude = Any(122.133333, help='Assigns longitude for view location').tag(wwt='locationLng', sync=True)
+    location_altitude  = AstropyQuantity(0 * u.m, help='Assigns altitude (in meters) for view location').tag(wwt='locationAltitude', sync=True)
+    location_latitude  = AstropyQuantity(47.633 * u.deg, help='Assigns latitude for view location').tag(wwt='locationLat', sync=True)
+    location_longitude = AstropyQuantity(122.133333 * u.deg, help='Assigns longitude for view location').tag(wwt='locationLng', sync=True)
     
     @validate('location_altitude')
     def _validate_altitude(self,proposal):

--- a/pywwt/core.py
+++ b/pywwt/core.py
@@ -109,16 +109,16 @@ class BaseWWTWidget(HasTraits):
     @validate('location_latitude')
     def _validate_latitude(self,proposal):
         if proposal['value'].unit.physical_type == 'angle':
-            return proposal['value']
+            return proposal['value'].to(u.degree)
         else:
-            raise TraitError('location_latitude not in degrees')
+            raise TraitError('location_latitude not in angle units')
 
     @validate('location_longitude')
     def _validate_longitude(self,proposal):
         if proposal['value'].unit.physical_type == 'angle':
-            return proposal['value']
+            return proposal['value'].to(u.degree)
         else:
-            raise TraitError('location_longitude not in degrees')
+            raise TraitError('location_longitude not in angle units')
 
     def load_image_collection(self, url):
         self._available_layers += get_imagery_layers(url)

--- a/pywwt/core.py
+++ b/pywwt/core.py
@@ -1,4 +1,4 @@
-from traitlets import Bool, HasTraits, Float, Unicode, Any, observe, validate, TraitError
+from traitlets import Bool, HasTraits, Float, Unicode, observe, validate, TraitError
 from astropy import units as u
 
 from .annotation import Circle, Poly, PolyLine

--- a/pywwt/core.py
+++ b/pywwt/core.py
@@ -26,11 +26,17 @@ class BaseWWTWidget(HasTraits):
         # its own, we only want to react to changes in traits that have the wwt
         # metadata attribute (which indicates the name of the corresponding WWT
         # setting).
-        wwt_name = self.trait_metadata(changed['name'], 'wwt')
+        wwt_name  = self.trait_metadata(changed['name'], 'wwt')
+        new_value = changed['new']
         if wwt_name is not None:
-            self._send_msg(event='setting_set',
-                           setting=wwt_name,
-                           value=changed['new'])
+            if hasattr(new_value, 'value') and hasattr(new_value, 'unit'):
+                self._send_msg(event='setting_set',
+                               setting=wwt_name,
+                               value=new_value.value)                
+            else:
+                self._send_msg(event='setting_set',
+                               setting=wwt_name,
+                               value=new_value)
 
     def _send_msg(self, **kwargs):
         # This method should be overridden and should send the message to WWT
@@ -96,22 +102,22 @@ class BaseWWTWidget(HasTraits):
     
     @validate('location_altitude')
     def _validate_altitude(self,proposal):
-        if proposal['value'].unit in u.meter.find_equivalent_units():
-            return proposal['value'].to(u.meter).value
+        if proposal['value'].unit.physical_type == 'length':
+            return proposal['value'].to(u.meter)
         else:
             raise TraitError('location_altitude not in units of length')
-        
+   
     @validate('location_latitude')
     def _validate_latiitude(self,proposal):
         if proposal['value'].unit == u.degree:
-            return proposal['value'].value
+            return proposal['value']
         else:
             raise TraitError('location_latitude not in degrees')
-        
+
     @validate('location_longitude')
     def _validate_longitude(self,proposal):
         if proposal['value'].unit == u.degree:
-            return proposal['value'].value
+            return proposal['value']
         else:
             raise TraitError('location_longitude not in degrees')
 

--- a/pywwt/core.py
+++ b/pywwt/core.py
@@ -29,15 +29,13 @@ class BaseWWTWidget(HasTraits):
         # setting).
         wwt_name  = self.trait_metadata(changed['name'], 'wwt')
         new_value = changed['new']
-        if wwt_name is not None:
-            if hasattr(new_value, 'value') and hasattr(new_value, 'unit'):
-                self._send_msg(event='setting_set',
-                               setting=wwt_name,
-                               value=new_value.value)                
-            else:
-                self._send_msg(event='setting_set',
-                               setting=wwt_name,
-                               value=new_value)
+        if wwt_name is not None:            
+            if isinstance(new_value,u.Quantity):
+                new_value = new_value.value
+
+            self._send_msg(event='setting_set',
+                           setting=wwt_name,
+                           value=new_value)
 
     def _send_msg(self, **kwargs):
         # This method should be overridden and should send the message to WWT

--- a/pywwt/quantity_trait.py
+++ b/pywwt/quantity_trait.py
@@ -7,6 +7,6 @@ class AstropyQuantity(TraitType):
     info_text = 'Custom trait to handle astropy quantities with units'
 
     def validate(self, obj, value):
-        if hasattr(value, 'value') and hasattr(value, 'unit'):
+        if isinstance(value,u.Quantity):
             return value
         self.error(obj, value)

--- a/pywwt/quantity_trait.py
+++ b/pywwt/quantity_trait.py
@@ -3,8 +3,8 @@ from astropy import units as u
 
 class AstropyQuantity(TraitType):
 
-    default = 0 * u.deg
-    info_text = 'Custom trait to handle astropy quantities with units'
+    default = 0 * u.one
+    info_text = '\'Custom trait to handle astropy quantities with units\''
 
     def validate(self, obj, value):
         if isinstance(value,u.Quantity):

--- a/pywwt/quantity_trait.py
+++ b/pywwt/quantity_trait.py
@@ -1,0 +1,12 @@
+from traitlets import TraitType
+from astropy import units as u
+
+class AstropyQuantity(TraitType):
+
+    default = 0 * u.deg
+    info_text = 'Custom trait to handle astropy quantities with units'
+
+    def validate(self, obj, value):
+        if hasattr(value, 'value') and hasattr(value, 'unit'):
+            return value
+        self.error(obj, value)


### PR DESCRIPTION
1) I had to change the trait types from float to Any, but the unit check a) makes sure `proposal` is an astropy quantity, and b) raises an error if it's not the right type of quantity. Given that traitlets doesn't include data types with units, is this an acceptable workaround? 

2) Do you think it should still be possible for proposal to be a float and users have the option to choose which type they prefer? If it's a float, we could turn the unit check into an `elif` and first check if `proposal` is a float. 

3) What effect is location_altitude supposed to have in the widget? I see no discernible changes in the picture, even at Everest-level heights.

4. Is there a way to include all units of length for `location_altitude`? `find_equivalent_units()` was the best I found in astropy, but it leaves out km and other somewhat common units of height. Also, should imperial (or other) unit systems be included?