### PR TITLE
Method to load astropy tables [issue #5]

### DIFF
--- a/pywwt/annotation.py
+++ b/pywwt/annotation.py
@@ -100,7 +100,7 @@ class Circle(Annotation):
         elif proposal['value'].unit.is_equivalent(u.degree):
             return proposal['value'].to(u.degree)
         else:
-            raise TraitError('radius must be in pixel or arcsec equivalent unit')
+            raise TraitError('radius must be in pixel or degree equivalent unit')
 
     def set_center(self, coord):
         coord_icrs = coord.icrs
@@ -118,7 +118,7 @@ class Circle(Annotation):
                                       id=self.id,
                                       setting='skyRelative',
                                       value=True)
-            elif changed['new'].unit.is_equivalent(u.arcsec):
+            elif changed['new'].unit.is_equivalent(u.degree):
                 self.parent._send_msg(event='annotation_set',
                                       id=self.id,
                                       setting='skyRelative',

--- a/pywwt/core.py
+++ b/pywwt/core.py
@@ -150,6 +150,11 @@ class BaseWWTWidget(HasTraits):
                        hour=dt.hour, minute=dt.minute, second=dt.second,
                        millisecond=int(dt.microsecond / 1000.))
 
+    def plot_table(self, col, **kwargs):
+        col_icrs = col.icrs
+        for point in col_icrs:
+            test = self.create_circle(center=point,**kwargs)
+
     galactic_mode = Bool(False, help='Whether the galactic plane should be horizontal in the viewer (:class:`bool`)').tag(wwt='galacticMode')
     local_horizon_mode = Bool(False, help='Whether the view should be that of a local latitude, longitude, and altitude (:class:`bool`)').tag(wwt='localHorizonMode')
     location_altitude = AstropyQuantity(0 * u.m, help='The altitude of the viewing location (:class:`~astropy.units.Quantity`)').tag(wwt='locationAltitude')


### PR DESCRIPTION
I attempted to solve the issue above. The function takes a column of SkyCoord entries from an astropy table and generates circles one by one. Currently, they all share a name, which isn't optimal, but I haven't yet found the way to make them all distinct annotations.