### PR TITLE
Proper support for Jupyter lab

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 0.4.0 (unreleased)
 ------------------
 
-- No changes yet.
+- Fix compatibility with Jupyter Lab. [#63]
 
 0.3.0 (2017-12-20)
 ------------------

--- a/js/lib/index.js
+++ b/js/lib/index.js
@@ -1,11 +1,6 @@
 // Entry point for the notebook bundle containing custom model definitions.
 //
 // Setup notebook base URL
-//
-// Some static assets may be required by the custom widget javascript. The base
-// url for the notebook is not known at build time and is therefore computed
-// dynamically.
-__webpack_public_path__ = document.querySelector('body').getAttribute('data-base-url') + 'nbextensions/pywwt/';
 
 // Export widget models and views, and the npm package version number.
 module.exports = require('./wwt.js');

--- a/js/lib/wwt.js
+++ b/js/lib/wwt.js
@@ -23,7 +23,7 @@ var WWTView = widgets.DOMWidgetView.extend({
         // otherwise support having multiple instances running on the same
         // page. We use the same HTML file as for the Qt client.
         var div = document.createElement("div");
-        div.innerHTML = "<iframe width='100%' height='480' style='border: none;' src='/wwt.html'></iframe>"
+        div.innerHTML = "<iframe width='100%' height='480' style='border: none;' src='wwt.html'></iframe>"
         this.el.appendChild(div);
 
         WWTView.__super__.initialize.apply(this, arguments);

--- a/js/lib/wwt.js
+++ b/js/lib/wwt.js
@@ -3,12 +3,15 @@ var _ = require("underscore");
 
 var WWTModel = widgets.DOMWidgetModel.extend({
     defaults: _.extend(widgets.DOMWidgetModel.prototype.defaults(), {
+
         _model_name : 'WWTModel',
-        _view_name : 'WWTView',
         _model_module : 'pywwt',
+        _model_module_version : '0.4.0',
+
+        _view_name : 'WWTView',
         _view_module : 'pywwt',
-        _model_module_version : '0.1.0',
-        _view_module_version : '0.1.0',
+        _view_module_version : '0.4.0',
+
     })
 });
 

--- a/js/lib/wwt.js
+++ b/js/lib/wwt.js
@@ -23,8 +23,7 @@ var WWTView = widgets.DOMWidgetView.extend({
         // otherwise support having multiple instances running on the same
         // page. We use the same HTML file as for the Qt client.
         var div = document.createElement("div");
-        nbextensions = requirejs.s.contexts._.config.paths.nbextensions;
-        div.innerHTML = "<iframe width='100%' height='480' style='border: none;' src='" + nbextensions + "/pywwt/wwt.html'></iframe>"
+        div.innerHTML = "<iframe width='100%' height='480' style='border: none;' src='/wwt.html'></iframe>"
         this.el.appendChild(div);
 
         WWTView.__super__.initialize.apply(this, arguments);

--- a/js/lib/wwt.js
+++ b/js/lib/wwt.js
@@ -23,7 +23,21 @@ var WWTView = widgets.DOMWidgetView.extend({
         // otherwise support having multiple instances running on the same
         // page. We use the same HTML file as for the Qt client.
         var div = document.createElement("div");
-        div.innerHTML = "<iframe width='100%' height='480' style='border: none;' src='wwt.html'></iframe>"
+
+        try {
+          // This should work for Jupyter notebook
+          nbextensions = requirejs.s.contexts._.config.paths.nbextensions;
+        } catch(e) {
+          // We should get here in Jupyter lab
+          nbextensions = null;
+        }
+
+        if (nbextensions == null) {
+          div.innerHTML = "<iframe width='100%' height='480' style='border: none;' src='wwt.html'></iframe>"
+        } else {
+          div.innerHTML = "<iframe width='100%' height='480' style='border: none;' src='" + nbextensions + "/pywwt/wwt.html'></iframe>"
+        }
+
         this.el.appendChild(div);
 
         WWTView.__super__.initialize.apply(this, arguments);

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pywwt",
-  "version": "0.4.0dev0",
+  "version": "0.4.0",
   "description": "WorldWide Telescope Jupyter widget",
   "author": "Thomas P. Robitaille, O. Justin Otor, and John ZuHone",
   "license" : "BSD-3-Clause",

--- a/pywwt/__init__.py
+++ b/pywwt/__init__.py
@@ -1,6 +1,7 @@
 from ._version import version_info, __version__  # noqa
 from .core import *  # noqa
 from .annotation import *  # noqa
+from .jupyter_server import load_jupyter_server_extension  # noqa
 
 
 def _jupyter_nbextension_paths():
@@ -8,3 +9,7 @@ def _jupyter_nbextension_paths():
              'src': 'static',
              'dest': 'pywwt',
              'require': 'pywwt/extension'}]
+
+
+def _jupyter_server_extension_paths():
+    return [{"module": "pywwt"}]

--- a/pywwt/jupyter.py
+++ b/pywwt/jupyter.py
@@ -30,8 +30,8 @@ class WWTJupyterWidget(widgets.DOMWidget, BaseWWTWidget):
     _model_name = Unicode('WWTModel').tag(sync=True)
     _view_module = Unicode('pywwt').tag(sync=True)
     _model_module = Unicode('pywwt').tag(sync=True)
-    _view_module_version = Unicode('^0.1.0').tag(sync=True)
-    _model_module_version = Unicode('^0.1.0').tag(sync=True)
+    _view_module_version = Unicode('0.4.0').tag(sync=True)
+    _model_module_version = Unicode('0.4.0').tag(sync=True)
 
     def __init__(self):
         widgets.DOMWidget.__init__(self)

--- a/pywwt/jupyter_server.py
+++ b/pywwt/jupyter_server.py
@@ -1,0 +1,31 @@
+import os
+from notebook.utils import url_path_join
+from notebook.base.handlers import IPythonHandler
+
+__all__ = ['load_jupyter_server_extension']
+
+
+class WWTHTMLHandler(IPythonHandler):
+    def get(self):
+        with open(os.path.join(os.path.dirname(__file__), 'static', 'wwt.html')) as f:
+            content = f.read()
+        self.finish(content)
+
+
+class WWTJSHandler(IPythonHandler):
+    def get(self):
+        with open(os.path.join(os.path.dirname(__file__), 'static', 'wwt_json_api.js')) as f:
+            content = f.read()
+        self.finish(content)
+
+
+def load_jupyter_server_extension(nb_server_app):
+
+    web_app = nb_server_app.web_app
+    host_pattern = '.*$'
+
+    route_pattern = url_path_join(web_app.settings['base_url'], '/wwt.html')
+    web_app.add_handlers(host_pattern, [(route_pattern, WWTHTMLHandler)])
+
+    route_pattern = url_path_join(web_app.settings['base_url'], '/wwt_json_api.js')
+    web_app.add_handlers(host_pattern, [(route_pattern, WWTJSHandler)])

--- a/pywwt/static/wwt.html
+++ b/pywwt/static/wwt.html
@@ -8,7 +8,7 @@
     <title>Simple WWT Web Client</title>
     <script src="https://WorldWideTelescope.github.io/pywwt/wwtsdk.aspx"></script>
     <script src="https://code.jquery.com/jquery-1.8.3.min.js"></script>
-    <script src="wwt_json_api.js"></script>
+    <script src="/wwt_json_api.js"></script>
 
     <!-- The following is to avoid scrollbars -->
     <style type="text/css">

--- a/pywwt/static/wwt.html
+++ b/pywwt/static/wwt.html
@@ -8,7 +8,7 @@
     <title>Simple WWT Web Client</title>
     <script src="https://WorldWideTelescope.github.io/pywwt/wwtsdk.aspx"></script>
     <script src="https://code.jquery.com/jquery-1.8.3.min.js"></script>
-    <script src="/wwt_json_api.js"></script>
+    <script src="wwt_json_api.js"></script>
 
     <!-- The following is to avoid scrollbars -->
     <style type="text/css">

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,4 +47,4 @@ url =
 edit_on_github = True
 github_project = astrofrog/pywwt
 install_requires = astropy
-version = 0.1.dev0
+version = 0.4.dev0


### PR DESCRIPTION
This is just an experimental branch as I'm at a Jupyter widgets workshop this week.

Things to do/figure out:

* [x] Preserve compatibility with notebook, might need to serve separate static files from notebook version
* [ ] Whether using a server extension to serve the html and js file is going to be problematic for e.g. binder or Azure notebook
* [ ] How to automatically install the server extension
* [ ] How to improve performance of WWT when split into a side panel
* [ ] Better resize canvas based on available space so it works in tabs/side panels