### PR TITLE
Added GUI controls for layers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@
 
 - Fix compatibility with Jupyter Lab. [#63]
 
+- Added GUI controls for imagery layers. [#64]
+
 0.3.0 (2017-12-20)
 ------------------
 

--- a/pywwt/core.py
+++ b/pywwt/core.py
@@ -205,6 +205,8 @@ class BaseWWTWidget(HasTraits):
     @observe('foreground')
     def _on_foreground_change(self, changed):
         self._send_msg(event='set_foreground_by_name', name=changed['new'])
+        # Changing a layer resets the opacity, so we re-trigger the opacity setting
+        self._send_msg(event='set_foreground_opacity', value=self.foreground_opacity * 100)
 
     @validate('foreground')
     def _validate_foreground(self, proposal):
@@ -218,6 +220,8 @@ class BaseWWTWidget(HasTraits):
     @observe('background')
     def _on_background_change(self, changed):
         self._send_msg(event='set_background_by_name', name=changed['new'])
+        # Changing a layer resets the opacity, so we re-trigger the opacity setting
+        self._send_msg(event='set_foreground_opacity', value=self.foreground_opacity * 100)
 
     @validate('background')
     def _validate_background(self, proposal):

--- a/pywwt/jupyter.py
+++ b/pywwt/jupyter.py
@@ -7,7 +7,7 @@ import sys
 PY2 = sys.version_info[0] == 2
 
 import ipywidgets as widgets
-from traitlets import Unicode, default
+from traitlets import Unicode, default, link
 
 if not PY2:
     from ipyevents import Event as DOMListener
@@ -40,6 +40,7 @@ class WWTJupyterWidget(widgets.DOMWidget, BaseWWTWidget):
             dom_listener.source = self
             dom_listener.prevent_default_action = True
             dom_listener.watched_events = ['wheel']
+        self._controls = None
 
     @default('layout')
     def _default_layout(self):
@@ -47,3 +48,18 @@ class WWTJupyterWidget(widgets.DOMWidget, BaseWWTWidget):
 
     def _send_msg(self, **kwargs):
         self.send(kwargs)
+
+    @property
+    def layer_controls(self):
+        if self._controls is None:
+            opacity_slider = widgets.FloatSlider(value=self.foreground_opacity,
+                                                 min=0, max=1, readout=False)
+            foreground_menu = widgets.Dropdown(options=self.available_layers,
+                                               value=self.foreground)
+            background_menu = widgets.Dropdown(options=self.available_layers,
+                                               value=self.background)
+            link((opacity_slider, 'value'), (self, 'foreground_opacity'))
+            link((foreground_menu, 'value'), (self, 'foreground'))
+            link((background_menu, 'value'), (self, 'background'))
+            self._controls = widgets.HBox([background_menu, opacity_slider, foreground_menu])
+        return self._controls


### PR DESCRIPTION
This adds GUI controls for setting the foreground, background, and foreground opacity. These controls can be shown by doing ``wwt.layer_controls``. I want to add a mention of this to the docs. We could also decide to show these by default with the WWT widget, but some users might not want it so it could be an option.

**Preview:**

<img width="880" alt="screen shot 2018-01-24 at 16 12 09" src="https://user-images.githubusercontent.com/314716/35339630-5f06edfa-0121-11e8-90cb-c9802c69b23e.png">
