### PR TITLE
Fix resizing of WWT in Jupyter Lab

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 0.4.0 (unreleased)
 ------------------
 
-- Fix compatibility with Jupyter Lab. [#63]
+- Fix compatibility with Jupyter Lab. [#63, #65]
 
 - Added GUI controls for imagery layers. [#64]
 

--- a/pywwt/jupyter.py
+++ b/pywwt/jupyter.py
@@ -44,7 +44,7 @@ class WWTJupyterWidget(widgets.DOMWidget, BaseWWTWidget):
 
     @default('layout')
     def _default_layout(self):
-        return widgets.Layout(height='480px', align_self='stretch')
+        return widgets.Layout(height='400px', align_self='stretch')
 
     def _send_msg(self, **kwargs):
         self.send(kwargs)


### PR DESCRIPTION
When WWT is moved to a separate panel in Jupyter Lab, it will now get resized correctly. However, the approach here is somewhat hacky and some things should probably be fixed upstream to make some of these things easier, so will open an issue in the Jupyter Lab repo.

![screen shot 2018-01-25 at 21 02 26](https://user-images.githubusercontent.com/314716/35410083-77cc13c6-0214-11e8-947d-6fb712594632.png)
