### PR TITLE
Attempted solution for tab completing layers

### DIFF
--- a/pywwt/core.py
+++ b/pywwt/core.py
@@ -8,6 +8,7 @@ from .traits import Color, Bool, Float, Unicode, AstropyQuantity
 
 from .annotation import Circle, Polygon, Line, CircleCollection
 from .imagery import get_imagery_layers
+from .layers import ImageryLayers
 
 # The WWT web control API is described here:
 # https://worldwidetelescope.gitbooks.io/worldwide-telescope-web-control-script-reference/content/
@@ -28,6 +29,7 @@ class BaseWWTWidget(HasTraits):
         super(BaseWWTWidget, self).__init__()
         self.observe(self._on_trait_change, type='change')
         self._available_layers = get_imagery_layers(DEFAULT_SURVEYS_URL)
+        self.imagery = ImageryLayers(self._available_layers)
 
         # NOTE: we deliberately don't force _on_trait_change to be called here
         # for the WWT settings, as the default values are hard-coded in wwt.html

--- a/pywwt/core.py
+++ b/pywwt/core.py
@@ -311,12 +311,12 @@ class BaseWWTWidget(HasTraits):
         Parameters
         ----------
         points : `~astropy.units.Quantity`
-            The desired points that will serve as the centers of the circles
-            that make up the collection. Requires at least two sets of
-            coordinates for initialization.
+            The desired points that will serve as the centers of the
+            circles that make up the collection. Requires at least two
+            sets of coordinates for initialization.
         kwargs
-            Optional arguments that allow corresponding Circle or Annotation
-            attributes to be set upon shape initialization.
+            Optional arguments that allow corresponding Circle or
+            Annotation attributes to be set upon shape initialization.
         """
         collection = CircleCollection(self, points, **kwargs)
         return collection

--- a/pywwt/layers.py
+++ b/pywwt/layers.py
@@ -21,47 +21,39 @@ class ImageryLayers():
         # Helps turn the list of layer names used to initialize the class
         # (og_list) into a dict.
         for layer in og_list:
-            ind = 0
 
             if re.search(r'(?i)gamma',layer) is not None:
                 self._add2dict(self._layers, layer, 'gamma')
                 continue # automatically advance to next iteration
 
-            ind += 1
             if re.search(r'(?i)x(-|\s)?ray',layer) is not None:
                 self._add2dict(self._layers, layer, 'x')
                 continue
 
-            ind += 1
             if (re.search(r'(?i)ultra(-|\s)?violet',layer) is not None or
                 re.search(r'(?i)[^\d\w]+uv|uv[^\d\w]+',layer) is not None):
                 self._add2dict(self._layers, layer, 'uv')
                 continue
 
-            ind += 1
             if (re.search(r'(?i)optical',layer) is not None or
                 re.search(r'(?i)visible',layer) is not None):
                 self._add2dict(self._layers, layer, 'visible')
                 continue
 
-            ind += 1    
             if (re.search(r'(?i)infrared',layer) is not None or
                 re.search(r'(?i)[^\d\w]+ir|ir[^\d\w]+',layer) is not None):
                 self._add2dict(self._layers, layer, 'ir')
                 continue
 
-            ind += 1
             if (re.search(r'(?i)microwave',layer) is not None or
                 re.search(r'(?i)[^\d\w]+cmb|cmb[^\d\w]+',layer) is not None):
                 self._add2dict(self._layers, layer, 'micro')
                 continue
 
-            ind += 1
             if re.search(r'(?i)radio',layer) is not None:
                 self._add2dict(self._layers, layer, 'radio')
                 continue
 
-            ind += 1
             self._add2dict(self._layers, layer, 'other')
 
     def _add2dict(self, diction, full_layer, bandpass):

--- a/pywwt/layers.py
+++ b/pywwt/layers.py
@@ -24,45 +24,45 @@ class ImageryLayers():
             ind = 0
 
             if re.search(r'(?i)gamma',layer) is not None:
-                self._add2dict(self._layers, layer, self._spectrum[ind])
+                self._add2dict(self._layers, layer, 'gamma')
                 continue # automatically advance to next iteration
 
             ind += 1
             if re.search(r'(?i)x(-|\s)?ray',layer) is not None:
-                self._add2dict(self._layers, layer, self._spectrum[ind])
+                self._add2dict(self._layers, layer, 'x')
                 continue
 
             ind += 1
             if (re.search(r'(?i)ultra(-|\s)?violet',layer) is not None or
                 re.search(r'(?i)[^\d\w]+uv|uv[^\d\w]+',layer) is not None):
-                self._add2dict(self._layers, layer, self._spectrum[ind])
+                self._add2dict(self._layers, layer, 'uv')
                 continue
 
             ind += 1
             if (re.search(r'(?i)optical',layer) is not None or
                 re.search(r'(?i)visible',layer) is not None):
-                self._add2dict(self._layers, layer, self._spectrum[ind])
+                self._add2dict(self._layers, layer, 'visible')
                 continue
 
             ind += 1    
             if (re.search(r'(?i)infrared',layer) is not None or
                 re.search(r'(?i)[^\d\w]+ir|ir[^\d\w]+',layer) is not None):
-                self._add2dict(self._layers, layer, self._spectrum[ind])
+                self._add2dict(self._layers, layer, 'ir')
                 continue
 
             ind += 1
             if (re.search(r'(?i)microwave',layer) is not None or
                 re.search(r'(?i)[^\d\w]+cmb|cmb[^\d\w]+',layer) is not None):
-                self._add2dict(self._layers, layer, self._spectrum[ind])
+                self._add2dict(self._layers, layer, 'micro')
                 continue
 
             ind += 1
             if re.search(r'(?i)radio',layer) is not None:
-                self._add2dict(self._layers, layer, self._spectrum[ind])
+                self._add2dict(self._layers, layer, 'radio')
                 continue
 
             ind += 1
-            self._add2dict(self._layers, layer, self._spectrum[ind])
+            self._add2dict(self._layers, layer, 'other')
 
     def _add2dict(self, diction, full_layer, bandpass):
         # Handles a layer's (full_layer) actual addition to the master
@@ -80,7 +80,6 @@ class ImageryLayers():
 
         diction[bandpass][short] = {}
         diction[bandpass][short]['full_name'] = full_layer
-        diction[bandpass][short]['thumbnail'] = None
 
     def _shorten(self, string):
         # Unlocks tab completion by shortening a full layer's name

--- a/pywwt/layers.py
+++ b/pywwt/layers.py
@@ -1,0 +1,100 @@
+import re
+
+class ImageryLayers():
+
+    def __init__(self, layer_list):
+        self._layers = {}
+        self._spectrum = ['gamma', 'x', 'uv', 'visible', 'ir', 'micro', 'radio', 'other']
+        for band in self._spectrum:
+            self._layers[band] = {}
+        
+        self._list2dict(layer_list)
+
+    def _list2dict(self, og_list):
+        for layer in og_list:
+            ind = 0
+
+            if(re.search(r'(?i)gamma',layer) != None):
+                self._add2dict(self._layers, layer, ind)
+                continue # automatically advance to next iteration
+
+            ind += 1
+            if(re.search(r'(?i)x(-|\s)?ray',layer) != None):
+                self._add2dict(self._layers, layer, ind)
+                continue
+
+            ind += 1
+            if(re.search(r'(?i)ultra(-|\s)?violet',layer) != None or 
+                 re.search(r'(?i)[^\d\w]+uv|uv[^\d\w]+',layer) != None):
+                self._add2dict(self._layers, layer, ind)
+                continue
+
+            ind += 1
+            if(re.search(r'(?i)optical',layer) != None or 
+                 re.search(r'(?i)visible',layer) != None):
+                self._add2dict(self._layers, layer, ind)
+                continue
+
+            ind += 1    
+            if(re.search(r'(?i)infrared',layer) != None or 
+                 re.search(r'(?i)[^\d\w]+ir|ir[^\d\w]+',layer) != None):
+                self._add2dict(self._layers, layer, ind)
+                continue
+
+            ind += 1
+            if(re.search(r'(?i)microwave',layer) != None or 
+                 re.search(r'(?i)[^\d\w]+cmb|cmb[^\d\w]+',layer) != None):
+                self._add2dict(self._layers, layer, ind)
+                continue
+
+            ind += 1
+            if(re.search(r'(?i)radio',layer) != None):
+                self._add2dict(self._layers, layer, ind)
+                continue
+
+            ind += 1
+            self._add2dict(self._layers, layer, ind)
+
+    def _add2dict(self, diction, full_layer, ind):
+        abbr = self._shorten(full_layer)
+
+        # check if abbr already exists in diction
+        j = 2
+        while(abbr in diction[self._spectrum[ind]]):
+            if(str(j-1) in abbr):
+                abbr = abbr[:-1]
+
+            abbr += str(j)
+            j += 1
+
+        diction[self._spectrum[ind]][abbr] = {}
+        diction[self._spectrum[ind]][abbr]['full_name'] = full_layer
+        diction[self._spectrum[ind]][abbr]['thumbnail'] = None
+
+    def _shorten(self, string):
+        first = string[:re.search(r'[\W]', string).start()].lower()
+
+        # just for 2MASS; use num2words to standardize process?
+        check = re.search(r'2', first)
+        if(check != None):
+            first = first[:check.start()] + 'two' + first[check.start()+1:]
+
+        return first
+
+    def __dir__(self):
+        return sorted(self._layers.keys())
+
+    def __getattr__(self, band):
+        return Bandpass(self._layers[band])
+
+
+class Bandpass():
+
+    def __init__(self, band):
+        self._band = band
+
+    def __dir__(self):
+        return sorted(self._band.keys())
+
+    def __getattr__(self, name):
+        return self._band[name]['full_name']

--- a/pywwt/layers.py
+++ b/pywwt/layers.py
@@ -8,7 +8,10 @@ class ImageryLayers():
 
     def __init__(self, layer_list):
         self._layers = {}
-        self._spectrum = ['gamma', 'x', 'uv', 'visible', 'ir', 'micro', 'radio', 'other']
+        self._spectrum = ['gamma', 'x', 'uv', 'visible',
+                          'ir', 'micro', 'radio', 'other']
+        self.integers = ['zero', 'one', 'two', 'three', 'four',
+                         'five', 'six', 'seven', 'eight', 'nine']
         for band in self._spectrum:
             self._layers[band] = {}
         
@@ -70,10 +73,10 @@ class ImageryLayers():
         while short in diction[bandpass]:
             if suffix:
                 suffix += 1
-                short += str(suffix)
             else:
                 suffix = 1
-                short += str(suffix)
+                
+            short += str(suffix)
 
         diction[bandpass][short] = {}
         diction[bandpass][short]['full_name'] = full_layer
@@ -81,15 +84,23 @@ class ImageryLayers():
 
     def _shorten(self, string):
         # Unlocks tab completion by shortening a full layer's name
-        # (string) to a valid Python name based on its first word.
-        first = string[:re.search(r'[\W]', string).start()].lower()
+        # (string) to a valid Python name based on its first word.        
+        cut_left = re.search(r'^[_\W]+', string)
+        if cut_left is not None:
+            string = string[cut_left.end():]
 
-        # just for 2MASS; use num2words to standardize process?
-        check = re.search(r'2', first)
-        if check is not None:
-            first = first[:check.start()] + 'two' + first[check.start()+1:]
+        cut_right = re.search(r'[_\W]', string)
+        if cut_right is not None:
+            string = string[:cut_right.start()].lower()
+        
+        digit = re.search(r'^\d', string)
+        if digit is not None:
+            for i, num in enumerate(self.integers, 0):
+                if str(i) == digit.group(0):
+                    string = string[:digit.start()] + num + string[digit.end():]
+                    break
 
-        return first
+        return string
 
     def __dir__(self):
         return sorted(self._layers.keys())


### PR DESCRIPTION
Here's my method to a) allow users to tab complete layer names, and b) automatically sort new layers by wavelength band.

I combined your proof-of-concept with regular expressions to look for key words in the strings that comprise the layer names ('UV', 'microwave', etc.). This way, if a user decides to upload more layers, they'll automatically be sorted.

I also use regular expressions to shorten the layer names and specifically change '2MASS' to 'twomass'. I also read about a package that converts integers to their string representations (e.g. 6 to 'six'); let me know if you want me to integrate into `layers.py` as well.

Then, I add one line to `core.py`, and it allows for layers to be changed like so:
`wwt.foreground = wwt.imagery.x.rass`.

I'm not sure how to check if properties show up in the docs, or if you would want these to do so in the first place.