### PR TITLE
Update WWT SDK URL

### DIFF
--- a/pywwt/static/wwt.html
+++ b/pywwt/static/wwt.html
@@ -6,7 +6,7 @@
     <meta charset="utf-8" http-equiv="X-UA-Compatible" content="chrome=1, IE=edge"/>
 
     <title>Simple WWT Web Client</title>
-    <script src="https://WorldWideTelescope.github.io/pywwt/wwtsdk.aspx"></script>
+    <script src="https://WorldWideTelescope.github.io/pywwt/wwtsdk.js"></script>
     <script src="https://code.jquery.com/jquery-1.8.3.min.js"></script>
     <script src="wwt_json_api.js"></script>
 


### PR DESCRIPTION
This now uses the latest SDK from http://worldwidetelescope.org/html5sdk/2.0/wwtsdk.js