### PR TITLE
Keyboard-controlled zoom

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,8 @@
 0.4.0 (unreleased)
 ------------------
 
+- Added keyboard shorcuts for movement in-viewer. [#81]
+
 - Disable crosshairs by default. [#157]
 
 - Added ``pause_time`` and ``play_time`` for controlling time and make it

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -51,6 +51,7 @@ User guide
    annotations
    layers
    fov
+   shortcuts
    tours
    windows
    api

--- a/docs/shortcuts.rst
+++ b/docs/shortcuts.rst
@@ -3,38 +3,55 @@
 Keyboard shortcuts
 ==================
 
-In both widgets, viewer navigation with the mouse follows typical conventions --
-click and drag up or down to move vertically; click and drag left or right to
-move horizontally; mouse wheel or pinch/two-finger scroll on a touchpad to zoom.
+In both the Qt and Jupyter widgets for WWT, viewer navigation with the mouse
+follows typical conventions -- click and drag up or down to move vertically;
+click and drag left or right to move horizontally; mouse wheel or
+pinch/two-finger scroll on a touchpad to zoom.
 
-In the Qt widget, it is also possible to navigate the viewer via keyboard
-shortcuts that are further explained below.  
+In the Qt widget (and the Jupyter widget in some browsers), it is also possible
+to navigate the viewer via keyboard shortcuts that are further explained below.
+ 
 
 Basic movements
 ---------------
 
 Imagining that the viewer's movements correspond with `an aircraft's principal
 axes of rotation <https://en.wikipedia.org/wiki/Aircraft_principal_axes>`_, you
-can perform two of the basic movements with the arrow keys alone:
+can perform two of the basic movements with the following keys:
 
-``up``, ``down``: pitch
-``left``, ``right``: yaw
+.. list-table::
+   :widths: auto
+
+   * - ``j`` or ``l``
+     - yaw
+   * - ``i`` or ``k``
+     - pitch
 
 To zoom, use:
 
-``z``: zoom in
-``x``: zoom out
+.. list-table::
+   :widths: auto
+
+   * - ``z``
+     - zoom in
+   * - ``x``
+     - zoom out
 
 Modified movements
 ------------------
 
-``alt`` allows you to access the third axis of rotation:
-``alt`` + ``left``, ``alt`` + ``right``: roll
+Use ``alt`` in combination with the directional keys to unlock more axes of
+movement:
 
-In individual planet modes, ``alt`` + ``up`` or ``down`` tilts the body
-vertically.
+.. list-table::
+   :widths: auto
+
+   * - ``alt`` + ``j`` or ``l``
+     - roll
+   * - ``alt`` + ``i`` or ``k``
+     - tilt vertically (individual planet modes only)
 
 Finally, adding ``shift`` to any of the above keys or combinations acts as a
 fine adjustment switch, performing the original action more slowly. For example,
-``shift`` + ``z`` zooms in at a slower pace, and ``shift`` + ``alt`` + ``left``
+``shift`` + ``z`` zooms in at a slower pace, and ``shift`` + ``alt`` + ``j``
 gives you a slower roll motion.

--- a/docs/shortcuts.rst
+++ b/docs/shortcuts.rst
@@ -1,0 +1,40 @@
+.. _layers:
+
+Keyboard shortcuts
+==================
+
+In both widgets, viewer navigation with the mouse follows typical conventions --
+click and drag up or down to move vertically; click and drag left or right to
+move horizontally; mouse wheel or pinch/two-finger scroll on a touchpad to zoom.
+
+In the Qt widget, it is also possible to navigate the viewer via keyboard
+shortcuts that are further explained below.  
+
+Basic movements
+---------------
+
+Imagining that the viewer's movements correspond with `an aircraft's principal
+axes of rotation <https://en.wikipedia.org/wiki/Aircraft_principal_axes>`_, you
+can perform two of the basic movements with the arrow keys alone:
+
+``up``, ``down``: pitch
+``left``, ``right``: yaw
+
+To zoom, use:
+
+``z``: zoom in
+``x``: zoom out
+
+Modified movements
+------------------
+
+``alt`` allows you to access the third axis of rotation:
+``alt`` + ``left``, ``alt`` + ``right``: roll
+
+In individual planet modes, ``alt`` + ``up`` or ``down`` tilts the body
+vertically.
+
+Finally, adding ``shift`` to any of the above keys or combinations acts as a
+fine adjustment switch, performing the original action more slowly. For example,
+``shift`` + ``z`` zooms in at a slower pace, and ``shift`` + ``alt`` + ``left``
+gives you a slower roll motion.

--- a/docs/shortcuts.rst
+++ b/docs/shortcuts.rst
@@ -1,4 +1,4 @@
-.. _layers:
+.. _shortcuts:
 
 Keyboard shortcuts
 ==================

--- a/pywwt/nbextension/static/wwt.html
+++ b/pywwt/nbextension/static/wwt.html
@@ -140,9 +140,9 @@
         
         zoomCodes = {"KeyZ": wheelUp, "KeyX": wheelDn, 
                      90: wheelUp, 88: wheelDn};
-        moveCodes = {"ArrowLeft": mouseLf, "ArrowUp": mouseUp, 
-                     "ArrowRight": mouseRg, "ArrowDown": mouseDn, 
-                     37: mouseLf, 38: mouseUp, 39: mouseRg, 40: mouseDn};
+        moveCodes = {"KeyJ": mouseLf, "KeyI": mouseUp, 
+                     "KeyL": mouseRg, "KeyK": mouseDn, 
+                     74: mouseLf, 73: mouseUp, 76: mouseRg, 75: mouseDn};
         
         window.addEventListener("keydown", function(event) {
           // must check the deprecated keyCode property for Qt          

--- a/pywwt/nbextension/static/wwt.html
+++ b/pywwt/nbextension/static/wwt.html
@@ -6,7 +6,7 @@
     <meta charset="utf-8" http-equiv="X-UA-Compatible" content="chrome=1, IE=edge"/>
 
     <title>Simple WWT Web Client</title>
-    <script src="https://worldwidetelescope.github.io/pywwt/wwtsdk.js"></script>
+    <script src="https://WorldWideTelescope.github.io/pywwt/wwtsdk.js"></script>
     <script src="https://code.jquery.com/jquery-1.8.3.min.js"></script>
     <script src="wwt_json_api.js"></script>
 
@@ -162,8 +162,8 @@
                          moveCodes[event.code] : moveCodes[event.keyCode];
             if (event.shiftKey) { action.shiftKey = 1; }
             else                { action.shiftKey = 0; }
-            if (event.ctrlKey) { action.ctrlKey = 1; }
-            else               { action.ctrlKey = 0; }
+            if (event.altKey) { action.altKey = 1; }
+            else               { action.altKey = 0; }
             canvas.dispatchEvent(action);
           }
         });
@@ -176,7 +176,7 @@
             if (event.shiftKey) { delay = 500; }
             else                { delay = 100; }
             setTimeout(function() {proceed = true}, delay);
-            if (event.ctrlKey)
+            if (event.altKey)
               wwtlib.WWTControl.singleton._tilt(event.movementX, event.movementY);
             else
               wwtlib.WWTControl.singleton.move(event.movementX, event.movementY);

--- a/pywwt/nbextension/static/wwt.html
+++ b/pywwt/nbextension/static/wwt.html
@@ -6,7 +6,7 @@
     <meta charset="utf-8" http-equiv="X-UA-Compatible" content="chrome=1, IE=edge"/>
 
     <title>Simple WWT Web Client</title>
-    <script src="https://WorldWideTelescope.github.io/pywwt/wwtsdk.js"></script>
+    <script src="https://worldwidetelescope.github.io/pywwt/wwtsdk.js"></script>
     <script src="https://code.jquery.com/jquery-1.8.3.min.js"></script>
     <script src="wwt_json_api.js"></script>
 
@@ -35,6 +35,7 @@
         // The true enables WebGL
         wwt = wwtlib.WWTControl.initControlParam("WWTCanvas", true);
         wwt.add_ready(wwtReady);
+        wwt.add_ready(keyScroll);
       }
 
       function wwtReady() {
@@ -89,8 +90,46 @@
 
       }
 
-    </script>
+      function keyScroll() {
+        i = 0;
+        var canvas = document.body.getElementsByTagName("canvas")[0];
+        var wheelUp = new WheelEvent("wheel", {deltaY: 53, delta: 53});
+        var wheelDown = new WheelEvent("wheel", {deltaY: -53, delta: -53});
 
+        window.addEventListener("keydown", function(event) {
+          if (event.code == "KeyZ") {
+            canvas.dispatchEvent(wheelUp);
+          }
+          else if (event.code == "KeyX")
+            canvas.dispatchEvent(wheelDown);
+        });
+
+        canvas.addEventListener("wheel", function(event) {
+          // wwtlib.WWTControl.singleton.renderContext.targetCamera.zoom
+          // gives you the current zoom level
+          // console.log(event);
+          var div = document.createElement("div");
+          div.style.height = "250px";
+          div.style.width = "250px";    
+          i += 1;
+          div.style.zIndex = i;
+          div.style.position = "absolute";
+          div.style.top = 0;
+          div.style.left = 0;
+          if (event.deltaY > 0) {
+            wwtlib.WWTControl.singleton.zoom(0.7);
+            div.style.background = "#ff0000";
+            document.body.appendChild(div);
+          }
+          else {
+            wwtlib.WWTControl.singleton.zoom(1.43);
+            div.style.background = "#0000ff";
+            document.body.appendChild(div);
+          }            
+        });
+      }
+
+    </script>
   </head>
 
   <body onload="initialize()" style="margin: 0; padding: 0">

--- a/pywwt/nbextension/static/wwt.html
+++ b/pywwt/nbextension/static/wwt.html
@@ -91,19 +91,40 @@
       }
 
       function keyScroll() {
+
+        // It seems that QWebEngine(Page) hasn't updated all of its JS standards,
+        // so we include deprecated methods to accomodate the Qt version in the
+        // try/catch clause and the first event listener.
+
         i = 0;
         var canvas = document.body.getElementsByTagName("canvas")[0];
-        var wheelUp = new WheelEvent("wheel", {deltaY: 53, delta: 53});
-        var wheelDown = new WheelEvent("wheel", {deltaY: -53, delta: -53});
+        
+        try {
+          var wheelUp = new WheelEvent("wheel", {deltaY: 53, delta: 53});
+          var wheelDn = new WheelEvent("wheel", {deltaY: -53, delta: -53});          
+        } catch (e) {
+          if (e instanceof TypeError) { // for Qt; initEvent is deprecated
+            var wheelUp = document.createEvent("CustomEvent");
+            wheelUp.initEvent("wheel", false, false, {deltaY: 53, delta: 53});
 
-        window.addEventListener("keydown", function(event) {
-          if (event.code == "KeyZ") {
-            canvas.dispatchEvent(wheelUp);
+            var wheelDn = document.createEvent("CustomEvent");
+            wheelDn.initEvent("wheel", false, false, {deltaY: -53, delta: -53});
+            
+            wheelUp.deltaY = 53;
+            wheelDn.deltaY = -53;
           }
-          else if (event.code == "KeyX")
-            canvas.dispatchEvent(wheelDown);
+          else
+            throw e;
+        }
+        
+        window.addEventListener("keydown", function(event) {
+          // must check keyCode for Qt; keyCode is deprecated
+          if (event.code == "KeyZ" || event.keyCode == 90)
+            canvas.dispatchEvent(wheelUp);
+          else if (event.code == "KeyX" || event.keyCode == 88)
+            canvas.dispatchEvent(wheelDn);
         });
-
+        
         canvas.addEventListener("wheel", function(event) {
           // wwtlib.WWTControl.singleton.renderContext.targetCamera.zoom
           // gives you the current zoom level
@@ -116,6 +137,7 @@
           div.style.position = "absolute";
           div.style.top = 0;
           div.style.left = 0;
+          div.innerHTML = event.deltaY;
           if (event.deltaY > 0) {
             wwtlib.WWTControl.singleton.zoom(0.7);
             div.style.background = "#ff0000";

--- a/pywwt/nbextension/static/wwt.html
+++ b/pywwt/nbextension/static/wwt.html
@@ -119,36 +119,49 @@
         
         window.addEventListener("keydown", function(event) {
           // must check keyCode for Qt; keyCode is deprecated
-          if (event.code == "KeyZ" || event.keyCode == 90)
+          if (event.code == "KeyZ" || event.keyCode == 90) {
+            if (event.shiftKey) { wheelUp.shiftKey = 1; }
+            else                { wheelUp.shiftKey = 0; }
             canvas.dispatchEvent(wheelUp);
-          else if (event.code == "KeyX" || event.keyCode == 88)
+          }
+          else if (event.code == "KeyX" || event.keyCode == 88) {
+            if (event.shiftKey) { wheelDn.shiftKey = 1; }
+            else                { wheelDn.shiftKey = 0; }
             canvas.dispatchEvent(wheelDn);
+          }
         });
         
-        canvas.addEventListener("wheel", function(event) {
-          // wwtlib.WWTControl.singleton.renderContext.targetCamera.zoom
-          // gives you the current zoom level
-          // console.log(event);
-          var div = document.createElement("div");
-          div.style.height = "250px";
-          div.style.width = "250px";    
-          i += 1;
-          div.style.zIndex = i;
-          div.style.position = "absolute";
-          div.style.top = 0;
-          div.style.left = 0;
-          div.innerHTML = event.deltaY;
-          if (event.deltaY > 0) {
-            wwtlib.WWTControl.singleton.zoom(0.7);
-            div.style.background = "#ff0000";
-            document.body.appendChild(div);
+        // use self-executing anon. function to make zoom smooth
+        canvas.addEventListener("wheel", (function(proceed) {
+          return function(event) {
+            if (!proceed) { return false; }
+            proceed = false;
+            
+            if (event.shiftKey) { delay = 500; } // milliseconds
+            else                { delay = 100; }
+            setTimeout(function() {proceed = true}, delay);
+
+            var div = document.createElement("div");
+            div.style.height = "100px";
+            div.style.width = "100px";    
+            i += 1;
+            div.style.zIndex = i;
+            div.style.position = "absolute";
+            div.style.top = 0;
+            div.style.left = 0;
+            div.innerHTML = event.shiftKey;
+            if (event.deltaY > 0) {
+              wwtlib.WWTControl.singleton.zoom(0.7);
+              div.style.background = "#ff0000";
+              document.body.appendChild(div);
+            }
+            else {
+              wwtlib.WWTControl.singleton.zoom(1.43);
+              div.style.background = "#0000ff";
+              document.body.appendChild(div);
+            }
           }
-          else {
-            wwtlib.WWTControl.singleton.zoom(1.43);
-            div.style.background = "#0000ff";
-            document.body.appendChild(div);
-          }            
-        });
+        })(true));
       }
 
     </script>

--- a/pywwt/nbextension/static/wwt.html
+++ b/pywwt/nbextension/static/wwt.html
@@ -101,17 +101,49 @@
         
         try {
           var wheelUp = new WheelEvent("wheel", {deltaY: 53, delta: 53});
-          var wheelDn = new WheelEvent("wheel", {deltaY: -53, delta: -53});          
+          var wheelDn = new WheelEvent("wheel", {deltaY: -53, delta: -53});
+
+          // using custom instead of mousemove so event fires more selectively
+          var mouseUp = new CustomEvent("move");
+          mouseRg.movementX = 0; mouseRg.movementY = 53;
+
+          var mouseLf = new CustomEvent("move");
+          mouseRg.movementX = 53; mouseRg.movementY = 0;
+
+          var mouseDn = new CustomEvent("move");
+          mouseRg.movementX = -53; mouseRg.movementY = -53;
+
+          var mouseRg = new CustomEvent("move");
+          mouseRg.movementX = -53; mouseRg.movementY = 0;
+
+          //var mouseRg = new MouseEvent("mousemove", {movementX: -53, movementY: 0});
         } catch (e) {
           if (e instanceof TypeError) { // for Qt; initEvent is deprecated
             var wheelUp = document.createEvent("CustomEvent");
-            wheelUp.initEvent("wheel", false, false, {deltaY: 53, delta: 53});
+            wheelUp.initEvent("wheel", false, false);
 
             var wheelDn = document.createEvent("CustomEvent");
-            wheelDn.initEvent("wheel", false, false, {deltaY: -53, delta: -53});
+            wheelDn.initEvent("wheel", false, false);
             
             wheelUp.deltaY = 53;
             wheelDn.deltaY = -53;
+
+            var mouseUp = document.createEvent("CustomEvent");
+            mouseUp.initCustomEvent("move", false, false);
+
+            var mouseLf = document.createEvent("CustomEvent");
+            mouseLf.initCustomEvent("move", false, false);
+
+            var mouseDn = document.createEvent("CustomEvent");
+            mouseDn.initCustomEvent("move", false, false);
+
+            var mouseRg = document.createEvent("CustomEvent");
+            mouseRg.initCustomEvent("move", false, false);
+
+            mouseUp.movementX = 0; mouseUp.movementY = 53;
+            mouseLf.movementX = 53; mouseLf.movementY = 0;
+            mouseDn.movementX = 0; mouseDn.movementY = -53;
+            mouseRg.movementX = -53; mouseRg.movementY = 0;
           }
           else
             throw e;
@@ -129,9 +161,47 @@
             else                { wheelDn.shiftKey = 0; }
             canvas.dispatchEvent(wheelDn);
           }
+// MIGHT WANT TO USE ARROW KEYS INSTEAD (ctrl+k, l etc. are browser shortcuts)
+          else if (event.code == "KeyI" || event.keyCode == 73) {
+            if (event.ctrlKey) { mouseUp.ctrlKey = 1; }
+            else               { mouseUp.ctrlKey = 0; }
+            canvas.dispatchEvent(mouseUp);
+          }
+          else if (event.code == "KeyJ" || event.keyCode == 74) {
+            if (event.ctrlKey) { mouseLf.ctrlKey = 1; }
+            else               { mouseLf.ctrlKey = 0; }
+            canvas.dispatchEvent(mouseLf);
+          }
+          else if (event.code == "KeyK" || event.keyCode == 75) {
+            if (event.ctrlKey) { mouseDn.ctrlKey = 1; }
+            else               { mouseDn.ctrlKey = 0; }
+            canvas.dispatchEvent(mouseDn);
+          }
+          else if (event.code == "KeyL" || event.keyCode == 76) {
+            if (event.ctrlKey) { mouseRg.ctrlKey = 1; }
+            else               { mouseRg.ctrlKey = 0; }
+            canvas.dispatchEvent(mouseRg);
+          }
         });
         
-        // use self-executing anon. function to make zoom smooth
+        canvas.addEventListener("move", (function(proceed) {
+          return function(event) {
+            //console.log(event);
+            if (!proceed) { return false; }
+            proceed = false;
+            
+            // need ctrl option as well
+            if (event.shiftKey) { delay = 500; }
+            else                { delay = 100; }
+            setTimeout(function() {proceed = true}, delay);
+            if (event.ctrlKey)
+              wwtlib.WWTControl.singleton._tilt(event.movementX, event.movementY);
+            else
+              wwtlib.WWTControl.singleton.move(event.movementX, event.movementY);
+          }
+        })(true));
+        
+        // use self-executing anonymous function to make zoom smooth
         canvas.addEventListener("wheel", (function(proceed) {
           return function(event) {
             if (!proceed) { return false; }
@@ -141,25 +211,8 @@
             else                { delay = 100; }
             setTimeout(function() {proceed = true}, delay);
 
-            var div = document.createElement("div");
-            div.style.height = "100px";
-            div.style.width = "100px";    
-            i += 1;
-            div.style.zIndex = i;
-            div.style.position = "absolute";
-            div.style.top = 0;
-            div.style.left = 0;
-            div.innerHTML = event.shiftKey;
-            if (event.deltaY > 0) {
-              wwtlib.WWTControl.singleton.zoom(0.7);
-              div.style.background = "#ff0000";
-              document.body.appendChild(div);
-            }
-            else {
-              wwtlib.WWTControl.singleton.zoom(1.43);
-              div.style.background = "#0000ff";
-              document.body.appendChild(div);
-            }
+            if (event.deltaY < 0) { wwtlib.WWTControl.singleton.zoom(1.43); }
+            else                  { wwtlib.WWTControl.singleton.zoom(0.7); }
           }
         })(true));
       }

--- a/pywwt/nbextension/static/wwt.html
+++ b/pywwt/nbextension/static/wwt.html
@@ -98,99 +98,81 @@
 
         i = 0;
         var canvas = document.body.getElementsByTagName("canvas")[0];
+
+        function newEvent(action, attributes, deprecated) {
+          if (!deprecated)
+            var event = new CustomEvent(action);
+          else {
+            var event = document.createEvent("CustomEvent");
+            event.initEvent(action, false, false);
+          }          
+          if (attributes)
+            for (var attr in attributes)
+              event[attr] = attributes[attr];
+
+          return event;
+        }
         
         try {
           var wheelUp = new WheelEvent("wheel", {deltaY: 53, delta: 53});
           var wheelDn = new WheelEvent("wheel", {deltaY: -53, delta: -53});
 
-          // using custom instead of mousemove so event fires more selectively
-          var mouseUp = new CustomEvent("move");
-          mouseRg.movementX = 0; mouseRg.movementY = 53;
-
-          var mouseLf = new CustomEvent("move");
-          mouseRg.movementX = 53; mouseRg.movementY = 0;
-
-          var mouseDn = new CustomEvent("move");
-          mouseRg.movementX = -53; mouseRg.movementY = -53;
-
-          var mouseRg = new CustomEvent("move");
-          mouseRg.movementX = -53; mouseRg.movementY = 0;
+          // using custom instead of default mousemove for more selective event firing
+          var mouseLf = newEvent("move", {movementX: 53, movementY: 0});
+          var mouseUp = newEvent("move", {movementX: 0, movementY: 53});
+          var mouseRg = newEvent("move", {movementX: -53, movementY: 0});
+          var mouseDn = newEvent("move", {movementX: 0, movementY: -53});
 
           //var mouseRg = new MouseEvent("mousemove", {movementX: -53, movementY: 0});
         } catch (e) {
           if (e instanceof TypeError) { // for Qt; initEvent is deprecated
-            var wheelUp = document.createEvent("CustomEvent");
-            wheelUp.initEvent("wheel", false, false);
+            var wheelUp = newEvent("wheel", {deltaY: 53}, true);
+            var wheelDn = newEvent("wheel", {deltaY: -53}, true);
 
-            var wheelDn = document.createEvent("CustomEvent");
-            wheelDn.initEvent("wheel", false, false);
-            
-            wheelUp.deltaY = 53;
-            wheelDn.deltaY = -53;
-
-            var mouseUp = document.createEvent("CustomEvent");
-            mouseUp.initCustomEvent("move", false, false);
-
-            var mouseLf = document.createEvent("CustomEvent");
-            mouseLf.initCustomEvent("move", false, false);
-
-            var mouseDn = document.createEvent("CustomEvent");
-            mouseDn.initCustomEvent("move", false, false);
-
-            var mouseRg = document.createEvent("CustomEvent");
-            mouseRg.initCustomEvent("move", false, false);
-
-            mouseUp.movementX = 0; mouseUp.movementY = 53;
-            mouseLf.movementX = 53; mouseLf.movementY = 0;
-            mouseDn.movementX = 0; mouseDn.movementY = -53;
-            mouseRg.movementX = -53; mouseRg.movementY = 0;
+            var mouseLf = newEvent("move", {movementX: 53, movementY: 0}, true);
+            var mouseUp = newEvent("move", {movementX: 0, movementY: 53}, true);
+            var mouseRg = newEvent("move", {movementX: -53, movementY: 0}, true);
+            var mouseDn = newEvent("move", {movementX: 0, movementY: -53}, true);
           }
           else
             throw e;
         }
         
+        zoomCodes = {"KeyZ": wheelUp, "KeyX": wheelDn, 
+                     90: wheelUp, 88: wheelDn};
+        moveCodes = {"ArrowLeft": mouseLf, "ArrowUp": mouseUp, 
+                     "ArrowRight": mouseRg, "ArrowDown": mouseDn, 
+                     37: mouseLf, 38: mouseUp, 39: mouseRg, 40: mouseDn};
+        
         window.addEventListener("keydown", function(event) {
-          // must check keyCode for Qt; keyCode is deprecated
-          if (event.code == "KeyZ" || event.keyCode == 90) {
-            if (event.shiftKey) { wheelUp.shiftKey = 1; }
-            else                { wheelUp.shiftKey = 0; }
-            canvas.dispatchEvent(wheelUp);
+          // must check the deprecated keyCode property for Qt          
+          
+          if (zoomCodes.hasOwnProperty(event.code) ||
+              zoomCodes.hasOwnProperty(event.keyCode)) {
+            var action = (typeof event.code !== "undefined") ? 
+                         zoomCodes[event.code] : zoomCodes[event.keyCode];
+            if (event.shiftKey) { action.shiftKey = 1; }
+            else                { action.shiftKey = 0; }
+            canvas.dispatchEvent(action);
           }
-          else if (event.code == "KeyX" || event.keyCode == 88) {
-            if (event.shiftKey) { wheelDn.shiftKey = 1; }
-            else                { wheelDn.shiftKey = 0; }
-            canvas.dispatchEvent(wheelDn);
-          }
-// MIGHT WANT TO USE ARROW KEYS INSTEAD (ctrl+k, l etc. are browser shortcuts)
-          else if (event.code == "KeyI" || event.keyCode == 73) {
-            if (event.ctrlKey) { mouseUp.ctrlKey = 1; }
-            else               { mouseUp.ctrlKey = 0; }
-            canvas.dispatchEvent(mouseUp);
-          }
-          else if (event.code == "KeyJ" || event.keyCode == 74) {
-            if (event.ctrlKey) { mouseLf.ctrlKey = 1; }
-            else               { mouseLf.ctrlKey = 0; }
-            canvas.dispatchEvent(mouseLf);
-          }
-          else if (event.code == "KeyK" || event.keyCode == 75) {
-            if (event.ctrlKey) { mouseDn.ctrlKey = 1; }
-            else               { mouseDn.ctrlKey = 0; }
-            canvas.dispatchEvent(mouseDn);
-          }
-          else if (event.code == "KeyL" || event.keyCode == 76) {
-            if (event.ctrlKey) { mouseRg.ctrlKey = 1; }
-            else               { mouseRg.ctrlKey = 0; }
-            canvas.dispatchEvent(mouseRg);
+          
+          if (moveCodes.hasOwnProperty(event.code) ||
+              moveCodes.hasOwnProperty(event.keyCode)) {
+            var action = (typeof event.code !== "undefined") ? 
+                         moveCodes[event.code] : moveCodes[event.keyCode];
+            if (event.shiftKey) { action.shiftKey = 1; }
+            else                { action.shiftKey = 0; }
+            if (event.ctrlKey) { action.ctrlKey = 1; }
+            else               { action.ctrlKey = 0; }
+            canvas.dispatchEvent(action);
           }
         });
         
         canvas.addEventListener("move", (function(proceed) {
           return function(event) {
-            //console.log(event);
             if (!proceed) { return false; }
             proceed = false;
             
-            // need ctrl option as well
             if (event.shiftKey) { delay = 500; }
             else                { delay = 100; }
             setTimeout(function() {proceed = true}, delay);


### PR DESCRIPTION
`z` to zoom in, `x` to zoom out. Any suggestions about zoom speed or smoothness?

There's still some debugging code in case I need to make changes, but this should work in both the Qt and Jupyter versions. Qt's web browser's standards aren't up-to-date as those of Chrome/Firefox/etc., so I had to add backwards compatibility to accommodate for that.

Now that I've figured out the problem with Qt, it seems like it wouldn't be difficult to add other keyboard controls.  Would that be useful?