### PR TITLE
Made quick fix for ss_scale error

### DIFF
--- a/pywwt/core.py
+++ b/pywwt/core.py
@@ -260,7 +260,7 @@ class BaseWWTWidget(HasTraits):
 
     @validate('ss_scale')
     def _validate_scale(self, proposal):
-        if 1 <= proposal <= 100:
+        if 1 <= proposal['value'] <= 100:
             return str(proposal['value'])
         else:
             raise ValueError('ss_scale takes integers from 1-100')


### PR DESCRIPTION
It was previously performing a check on the traitlets object as a whole instead of just its `value` attribute.