### PR TITLE
Moved solar system settings to proxy object

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -75,7 +75,7 @@ and smaller studies. They can also add a good amount of aesthetic value for
 tours or general use, and there are several methods of selecting them.
 
 About 20 layers of different wavelengths, scopes, and eras are currently 
-available. You can list them using the widget's ``available_layers`` method::
+available. You can list them using the widget's :meth:`~pywwt.BaseWWTWidget.available_layers` method::
 
     >>> wwt.available_layers
     ['2MASS: Catalog (Synthetic, Near Infrared)', '2Mass: Imagery (Infrared)',

--- a/docs/views.rst
+++ b/docs/views.rst
@@ -2,17 +2,18 @@ Switching views
 ===============
 
 New in release 0.4.0 is the ability to toggle between modes in the same manner 
-as in the WorldWide Telescope Web Client by using the ``set_view`` method. 
-Available modes include sky, planet, solar system, Milky Way, universe, and 
-panorama. The rest of the documentation is based on the default sky mode, so 
-here we discuss what makes the others different.
+as in the WorldWide Telescope Web Client by using the 
+:meth:`~pywwt.BaseWWTWidget.set_view` method. Available modes include sky, 
+planet, solar system, Milky Way, universe, and panorama. The rest of the 
+documentation is based on the default sky mode, so here we discuss what makes 
+the others different.
 
 Planet view
 -----------
 Use this mode to get individual views of most of the major objects in the solar 
 system -- the Sun, the planets, Pluto, Earth's Moon, and Jupiter's Galilean 
 satellites. To use this mode, enter the name of your desired object as the 
-argument for ``set_view``::
+argument for :meth:`~pywwt.BaseWWTWidget.set_view`::
 
     >>> wwt.set_view('Moon')
     
@@ -33,8 +34,7 @@ This mode displays all objects that orbit the Sun. To access it, enter::
 All attributes and methods of solar system mode are housed within the widget's 
 ``solar_system`` object so they're easier to find. Like the sky view, it's 
 possible to edit this view to your liking. For example, orbit paths are shown 
-by default, but if you would like to turn them off, use the ``orbits`` 
-attribute::
+by default, but if you would like to turn them off, use the :meth:`~pywwt.BaseWWTWidget.orbits` attribute::
 
     >> wwt.solar_system.orbits = False
     
@@ -43,9 +43,7 @@ useful attribute, ``scale``, enables you to change the size of the major
 objects on a scale from 1 (actual size) to 100. We plan to reveal more options
 soon to match those currently present in the Web Client.
 
-This mode also comes with its own method, ``track_object``, that centers the 
-viewer on a major solar system object of your choice as it both rotates and 
-follows its orbital path::
+This mode also comes with its own method, :meth:`~pywwt.BaseWWTWidget.track_object`, that centers the viewer on a major solar system object of your choice as it both rotates and follows its orbital path::
     
     >> wwt.solar_system.track_object('Jupiter')
 
@@ -72,9 +70,8 @@ The Universe view zooms all the way out to the extent of the observed universe:
 
 .. image:: images/universe.png
 
-.. note:: If you're ever lost inside a mode, the ``reset_view`` method 
-          backtracks to the mode's initial state and allows you to start your
-          exploration over again.
+.. note:: If you're ever lost inside a mode, backtrack to its initial state by
+          using the :meth:`~pywwt.BaseWWTWidget.reset_view` method.
 
 Panorama view
 -------------

--- a/docs/views.rst
+++ b/docs/views.rst
@@ -34,7 +34,8 @@ This mode displays all objects that orbit the Sun. To access it, enter::
 All attributes and methods of solar system mode are housed within the widget's 
 ``solar_system`` object so they're easier to find. Like the sky view, it's 
 possible to edit this view to your liking. For example, orbit paths are shown 
-by default, but if you would like to turn them off, use the :meth:`~pywwt.BaseWWTWidget.orbits` attribute::
+by default, but if you would like to turn them off, use the 
+:meth:`~pywwt.BaseWWTWidget.orbits` attribute::
 
     >> wwt.solar_system.orbits = False
     
@@ -43,7 +44,10 @@ useful attribute, ``scale``, enables you to change the size of the major
 objects on a scale from 1 (actual size) to 100. We plan to reveal more options
 soon to match those currently present in the Web Client.
 
-This mode also comes with its own method, :meth:`~pywwt.BaseWWTWidget.track_object`, that centers the viewer on a major solar system object of your choice as it both rotates and follows its orbital path::
+This mode also comes with its own method, 
+:meth:`~pywwt.BaseWWTWidget.track_object`, that centers the viewer on a major 
+solar system object of your choice as it both rotates and follows its orbital 
+path::
     
     >> wwt.solar_system.track_object('Jupiter')
 
@@ -75,6 +79,9 @@ The Universe view zooms all the way out to the extent of the observed universe:
 
 Panorama view
 -------------
-**Keep or no?**
-Finally, this view provides 360-degree panoramas taken during various NASA 
-missions to Mars and the Moon. (...)
+
+This view provides 360-degree panoramas taken during various NASA missions to 
+Mars and the Moon. It's currently only possible to explore a single image from 
+NASA's Pathfinder rover on Mars. The rest of the panoramas and their 
+view-specific functionalities will be imported from the Web Client in a future 
+release.

--- a/docs/views.rst
+++ b/docs/views.rst
@@ -3,8 +3,8 @@ Switching views
 
 New in release 0.4.0 is the ability to toggle between modes in the same manner 
 as in the WorldWide Telescope Web Client by using the ``set_view`` method. 
-Available modes include sky, planet, solar system, Milky Way, universe(, and 
-panorama). The rest of the documentation is based on the default sky mode, so 
+Available modes include sky, planet, solar system, Milky Way, universe, and 
+panorama. The rest of the documentation is based on the default sky mode, so 
 here we discuss what makes the others different.
 
 Planet view
@@ -23,32 +23,31 @@ Once you've done that, your view should resemble the following:
 Solar system, Milky Way, and Universe views
 -------------------------------------------
 
-These three views actually come from the same mode at different fields-of-view.
+These three views come from the same mode at different field-of-view levels.
 
 **Solar system**
 This mode displays all objects that orbit the Sun. To access it, enter::
 
     >>> wwt.set_view('solar_system')
 
-Like the sky view, it offers functionality to edit the view to your liking. For 
-example, orbit paths are shown by default, but if you would like to turn them 
-off, use the ``ss_orbits`` attribute::
+All attributes and methods of solar system mode are housed within the widget's 
+``solar_system`` object so they're easier to find. Like the sky view, it's 
+possible to edit this view to your liking. For example, orbit paths are shown 
+by default, but if you would like to turn them off, use the ``orbits`` 
+attribute::
 
-    >> wwt.ss_orbits = False
+    >> wwt.solar_system.orbits = False
     
 The objects themselves can also be hidden using a similar technique. Another 
-useful attribute, ``ss_scale``, allows you to change the size of the major 
-objects on a scale from 1 (actual size) to 100.
+useful attribute, ``scale``, enables you to change the size of the major 
+objects on a scale from 1 (actual size) to 100. We plan to reveal more options
+soon to match those currently present in the Web Client.
 
-All attributes that modify settings in solar system mode are prefixed with 
-"ss_" so they're easier to find, and we plan to reveal more of them soon to 
-match those currently present in the Web Client.
-
-This mode also comes with its own method, ``track_object``, which centers the 
+This mode also comes with its own method, ``track_object``, that centers the 
 viewer on a major solar system object of your choice as it both rotates and 
 follows its orbital path::
     
-    >> wwt.track_object('Jupiter')
+    >> wwt.solar_system.track_object('Jupiter')
 
 .. note::   ``track_object`` is similar in spirit and syntax to planet view, 
             but they are not the same. The former exists within the context of 
@@ -79,5 +78,6 @@ The Universe view zooms all the way out to the extent of the observed universe:
 
 Panorama view
 -------------
+**Keep or no?**
 Finally, this view provides 360-degree panoramas taken during various NASA 
 missions to Mars and the Moon. (...)

--- a/pywwt/core.py
+++ b/pywwt/core.py
@@ -11,6 +11,7 @@ from .traits import (Color, ColorWithOpacity, Bool,
 from .annotation import Circle, Polygon, Line, CircleCollection
 from .imagery import get_imagery_layers
 from .layers import ImageryLayers
+from .ss_proxy import SolarSystem
 
 # The WWT web control API is described here:
 # https://worldwidetelescope.gitbooks.io/worldwide-telescope-web-control-script-reference/content/
@@ -32,6 +33,7 @@ class BaseWWTWidget(HasTraits):
         self.observe(self._on_trait_change, type='change')
         self._available_layers = get_imagery_layers(DEFAULT_SURVEYS_URL)
         self.imagery = ImageryLayers(self._available_layers)
+        self.solar_system = SolarSystem(self)
         self._available_modes = ['sky', 'planet', 'solar_system',
                                  'milky_way', 'universe', 'panorama']
         self.current_mode = 'sky'
@@ -235,59 +237,6 @@ class BaseWWTWidget(HasTraits):
             return proposal['value'].to(u.degree)
         else:
             raise TraitError('location_longitude not in angle units')
-
-    #ss_cmb = Bool(False, help='Whether to show the cosmic microwave background in solar system mode (`bool`)').tag(wwt='solarSystemCMB') ###
-    #ss_cosmos = Bool(False, help='Whether to show data from the SDSS Cosmos data set (`bool`)').tag(wwt='solarSystemCosmos') ###
-    #ss_display = Bool(False, help='Whether to show the solar system while in solar system mode (`bool`)').tag(wwt='solarSystemOverlays') ###
-    #ss_lighting = Bool(False, help='Whether to show the lighting effect of the Sun on the solar system (`bool`)').tag(wwt='solarSystemLighting') ###
-    ss_milky_way = Bool(True,
-                        help='Whether to show the galactic bulge in the '
-                             'background in solar system mode '
-                             '(`bool`)').tag(wwt='solarSystemMilkyWay')
-    #ss_multi_res = Bool(False, help='Whether to show the multi-resolution textures for planets where available (`bool`)').tag(wwt='solarSystemMultiRes') ###
-    #ss_minor_orbits = Bool(False, help='Whether to show the orbits of minor planets in solar system mode (`bool`)').tag(wwt='solarSystemMinorOrbits') ###
-    #ss_minor_planets = Bool(False, help='Whether to show minor planets in solar system mode (`bool`)').tag(wwt='solarSystemMinorPlanets') ###
-    ss_orbits = Bool(True,
-                     help='Whether to show orbit paths when the solar system '
-                          'is displayed (`bool`)').tag(wwt='solarSystemOrbits')
-    ss_objects = Bool(True,
-                      help='Whether to show the objects of the solar system in '
-                           'solar system mode (`bool`)').tag(wwt='solarSystemPlanets')
-    ss_scale = Int(1, help='Specifies how to scale objects\' size in solar '
-                           'system mode, with 1 as actual size and 100 as the '
-                           'maximum (`int`)').tag(wwt='solarSystemScale')
-    #ss_stars = Bool(False, help='Whether to show background stars in solar system mode (`bool`)').tag(wwt='solarSystemStars') ###
-
-    @validate('ss_scale')
-    def _validate_scale(self, proposal):
-        if 1 <= proposal['value'] <= 100:
-            return str(proposal['value'])
-        else:
-            raise ValueError('ss_scale takes integers from 1-100')
-
-    def track_object(self, obj):
-        """
-        Focus the viewer on a particular object while in solar system mode.
-        Available objects include the Sun, the planets, the Moon, Jupiter's
-        Galilean moons, and Pluto.
-
-        Parameters
-        ----------
-        obj : `str`
-            The desired solar system object.
-        """
-        obj = obj.lower()
-        mappings = {'sun': 0, 'mercury': 1, 'venus': 2, 'mars': 3, 'jupiter': 4,
-                    'saturn': 5, 'uranus': 6, 'neptune': 7, 'pluto': 8,
-                    'moon': 9, 'io': 10, 'europa': 11, 'ganymede': 12,
-                    'callisto': 13, 'ioshadow': 14, 'europashadow': 15,
-                    'ganymedeshadow': 16, 'callistoshadow': 17,
-                    'suneclipsed': 18, 'earth': 19}
-
-        if obj in mappings:
-            self._send_msg(event='track_object', code=mappings[obj])
-        else:
-            raise ValueError('the given object cannot be tracked')
 
     def set_view(self, mode):
         """

--- a/pywwt/nbextension/static/wwt.html
+++ b/pywwt/nbextension/static/wwt.html
@@ -72,14 +72,13 @@
         wwt.settings.set_locationLat(47.633)
         wwt.settings.set_locationLng(122.133333)
         //wwt.settings.set_solarSystemCosmos(false) // in source, don't think works
-        //wwt.settings.set_solarSystemLighting(false) // in source, doesn't work
+        wwt.settings.set_solarSystemLighting(true) // in source, NOW works
         wwt.settings.set_solarSystemMilkyWay(true) // in source, works
         //wwt.settings.set_solarSystemMultiRes(false) // in source, don't think works
         wwt.settings.set_solarSystemOrbits(true) // in source, works
         //wwt.settings.set_solarSystemOverlays(false) // in source, doesn't work
         wwt.settings.set_solarSystemScale('1') // in source, works
         //wwt.settings.set_solarSystemStars(false) // in source, doesn't work
-        //set_solarSystemTrack? // in source, not sure how to call
         //wwt.settings.set_solarSystemCMB(false); // in source, doesn't work
         //wwt.settings.set_solarSystemMinorPlanets(false) // in source, doesn't work
         //wwt.settings.set_solarSystemMinorOrbits(false) // in source, doesn't work

--- a/pywwt/ss_proxy.py
+++ b/pywwt/ss_proxy.py
@@ -5,9 +5,9 @@ from .traits import Bool, Int
 
 class SolarSystem(HasTraits):
 
-    def __init__(self, BaseWWTWidget):
+    def __init__(self, base_wwt_widget):
         super(SolarSystem, self).__init__()
-        self.base_widget = BaseWWTWidget
+        self.base_widget = base_wwt_widget
         self.observe(self._on_trait_change, type='change')
 
     def _on_trait_change(self, changed):

--- a/pywwt/ss_proxy.py
+++ b/pywwt/ss_proxy.py
@@ -1,0 +1,79 @@
+from astropy import units as u
+from traitlets import HasTraits, observe, validate, TraitError
+
+from .traits import Bool, Int
+
+class SolarSystem(HasTraits):
+
+    def __init__(self, BaseWWTWidget):
+        super(SolarSystem, self).__init__()
+        self.base_widget = BaseWWTWidget
+        self.observe(self._on_trait_change, type='change')
+
+    def _on_trait_change(self, changed):
+        # This method gets called anytime a trait gets changed. Since this class
+        # gets inherited by the Jupyter widgets class which adds some traits of
+        # its own, we only want to react to changes in traits that have the wwt
+        # metadata attribute (which indicates the name of the corresponding WWT
+        # setting).
+        wwt_name = self.trait_metadata(changed['name'], 'wwt')
+        new_value = changed['new']
+        if wwt_name is not None:
+            if isinstance(new_value, u.Quantity):
+                new_value = new_value.value
+
+            self.base_widget._send_msg(event='setting_set',
+                                setting=wwt_name,
+                                value=new_value)
+
+    #cmb = Bool(False, help='Whether to show the cosmic microwave background in solar system mode (`bool`)').tag(wwt='solarSystemCMB') ###
+    #cosmos = Bool(False, help='Whether to show data from the SDSS Cosmos data set (`bool`)').tag(wwt='solarSystemCosmos') ###
+    #display = Bool(False, help='Whether to show the solar system while in solar system mode (`bool`)').tag(wwt='solarSystemOverlays') ###
+    #lighting = Bool(False, help='Whether to show the lighting effect of the Sun on the solar system (`bool`)').tag(wwt='solarSystemLighting') ###
+    milky_way = Bool(True, help='Whether to show the galactic bulge in the '
+                                'background in solar system mode '
+                                '(`bool`)').tag(wwt='solarSystemMilkyWay')
+    #multi_res = Bool(False, help='Whether to show the multi-resolution textures for planets where available (`bool`)').tag(wwt='solarSystemMultiRes') ###
+    #minor_orbits = Bool(False, help='Whether to show the orbits of minor planets in solar system mode (`bool`)').tag(wwt='solarSystemMinorOrbits') ###
+    #minor_planets = Bool(False, help='Whether to show minor planets in solar system mode (`bool`)').tag(wwt='solarSystemMinorPlanets') ###
+    orbits = Bool(True,
+                  help='Whether to show orbit paths when the solar system is '
+                       'displayed (`bool`)').tag(wwt='solarSystemOrbits')
+    objects = Bool(True, 
+                   help='Whether to show the objects of the solar system in '
+                        'solar system mode (`bool`)').tag(wwt='solarSystemPlanets')
+    scale = Int(1, help='Specifies how to scale objects\' size in solar '
+                        'system mode, with 1 as actual size and 100 as the '
+                        'maximum (`int`)').tag(wwt='solarSystemScale')
+    #stars = Bool(False, help='Whether to show background stars in solar system mode (`bool`)').tag(wwt='solarSystemStars') ###
+
+    @validate('scale')
+    def _validate_scale(self, proposal):
+        if 1 <= proposal['value'] <= 100:
+            return str(proposal['value'])
+        else:
+            raise ValueError('scale takes integers from 1-100')
+
+    def track_object(self, obj):
+        """
+        Focus the viewer on a particular object while in solar system mode.
+        Available objects include the Sun, the planets, the Moon, Jupiter's
+        Galilean moons, and Pluto.
+
+        Parameters
+        ----------
+        obj : `str`
+            The desired solar system object.
+        """
+        obj = obj.lower()
+        mappings = {'sun': 0, 'mercury': 1, 'venus': 2, 'mars': 3, 'jupiter': 4,
+                    'saturn': 5, 'uranus': 6, 'neptune': 7, 'pluto': 8,
+                    'moon': 9, 'io': 10, 'europa': 11, 'ganymede': 12,
+                    'callisto': 13, 'ioshadow': 14, 'europashadow': 15,
+                    'ganymedeshadow': 16, 'callistoshadow': 17,
+                    'suneclipsed': 18, 'earth': 19}
+
+        if obj in mappings:
+            self.base_widget._send_msg(event='track_object', code=mappings[obj])
+        else:
+            raise ValueError('the given object cannot be tracked')

--- a/pywwt/ss_proxy.py
+++ b/pywwt/ss_proxy.py
@@ -29,7 +29,9 @@ class SolarSystem(HasTraits):
     #cmb = Bool(False, help='Whether to show the cosmic microwave background in solar system mode (`bool`)').tag(wwt='solarSystemCMB') ###
     #cosmos = Bool(False, help='Whether to show data from the SDSS Cosmos data set (`bool`)').tag(wwt='solarSystemCosmos') ###
     #display = Bool(False, help='Whether to show the solar system while in solar system mode (`bool`)').tag(wwt='solarSystemOverlays') ###
-    #lighting = Bool(False, help='Whether to show the lighting effect of the Sun on the solar system (`bool`)').tag(wwt='solarSystemLighting') ###
+    lighting = Bool(True,
+                    help='Whether to show the lighting effect of the Sun on the'
+                         ' solar system (`bool`)').tag(wwt='solarSystemLighting')
     milky_way = Bool(True, help='Whether to show the galactic bulge in the '
                                 'background in solar system mode '
                                 '(`bool`)').tag(wwt='solarSystemMilkyWay')


### PR DESCRIPTION
Is it OK that tab-completion also shows the inherited methods from traitlets' `HasTrait` along with the solar system traits?

Edits to the docs are upcoming.