### PR TITLE
Temporary fix for instantaneous-like annotation property syncing

### DIFF
--- a/pywwt/annotation.py
+++ b/pywwt/annotation.py
@@ -132,6 +132,8 @@ class Circle(Annotation):
             changed['new'] = changed['new'].value
 
         super(Circle, self)._on_trait_change(changed)
+        dummy = Circle(self.parent)
+        dummy.remove()
 
 
 class Polygon(Annotation):
@@ -193,6 +195,8 @@ class Polygon(Annotation):
             changed['new'] = changed['new'].value
 
         super(Polygon, self)._on_trait_change(changed)
+        dummy = Circle(self.parent)
+        dummy.remove()
 
 
 class Line(Annotation):
@@ -250,6 +254,8 @@ class Line(Annotation):
             changed['new'] = changed['new'].value
 
         super(Line, self)._on_trait_change(changed)
+        dummy = Circle(self.parent)
+        dummy.remove()
 
 class CircleCollection():
     """


### PR DESCRIPTION
I add code in the trait observing function for each annotation class that creates and then deletes a dummy circle in order to trigger WebGL into updating properties for all shapes. It works as intended, although the only way to check is by making a circle and then changing its radius due to the developments mentioned in #106.