### PR TITLE
More layer improvements

### DIFF
--- a/pywwt/layers.py
+++ b/pywwt/layers.py
@@ -124,6 +124,7 @@ class TableLayer(HasTraits):
     size_scale = Float(1, help='The factor by which to scale the size of the points').tag(wwt='scaleFactor')
 
     color = Color('white', help='The color of the markers').tag(wwt='color')
+    opacity = Float(1, help='The opacity of the markers').tag(wwt='color')
 
     # TODO: support:
     # xAxisColumn
@@ -260,6 +261,10 @@ class TableLayer(HasTraits):
                 value = VALID_ALT_UNITS[value]
             elif changed['name'] == 'lon_unit':
                 value = VALID_LON_UNITS[value]
+            elif changed['name'] in ('color', 'opacity'):
+                wwt_name = 'color'
+                opacity_hex = "%0.2x" % int(self.opacity * 255)
+                value = opacity_hex + self.color[1:]
             # TODO: need to generalize to not say table here
             self.parent._send_msg(event='table_layer_set',
                                   id=self.id,

--- a/pywwt/nbextension/static/wwt_json_api.js
+++ b/pywwt/nbextension/static/wwt_json_api.js
@@ -178,10 +178,28 @@ function wwt_apply_json_message(wwt, msg) {
       wwt.layers[msg['id']] = layer;
       break;
 
-    case 'table_layer_set':
+    case 'table_layer_update':
 
       var layer = wwt.layers[msg['id']];
 
+      // Decode table from base64
+      csv = atob(msg['table']);
+
+      // FIXME: the SpreadSheetLayer loadFromString method rties
+      layer.loadFromString(csv, true, true, true, false)
+
+      // FIXME: workaround for the fact that at the moment, WWT appears
+      // to only refresh if the color is changed. So we change to black then
+      // back.
+      color = layer.get_color();
+      layer.set_color(wwtlib.Color.fromHex('#000000'));
+      layer.set_color(color);
+
+      break;
+
+    case 'table_layer_set':
+
+      var layer = wwt.layers[msg['id']];
       var name = msg['setting'];
 
       //if (name.includes('Column')) { // compatability issues?

--- a/pywwt/nbextension/static/wwt_json_api.js
+++ b/pywwt/nbextension/static/wwt_json_api.js
@@ -188,7 +188,7 @@ function wwt_apply_json_message(wwt, msg) {
       if (name.indexOf('Column') >= 0) {
         value = layer.get__table().header.indexOf(msg['value']);
       } else if(name == 'color') {
-        value = wwtlib.Color.fromHex(msg['value']);
+        value = wwtlib.Color.fromSimpleHex(msg['value']);
       } else if(name == 'altUnit') {
         value = wwtlib.AltUnits[msg['value']];
       } else if(name == 'raUnits') {

--- a/pywwt/nbextension/static/wwt_json_api.js
+++ b/pywwt/nbextension/static/wwt_json_api.js
@@ -165,6 +165,14 @@ function wwt_apply_json_message(wwt, msg) {
       layer = wwtlib.LayerManager.createSpreadsheetLayer(frame, "PyWWT Layer", csv);
       layer.set_referenceFrame(frame);
 
+      // FIXME: for now, this doesn't have any effect because WWT should add a 180
+      // degree offset but it doesn't - see
+      // https://github.com/WorldWideTelescope/wwt-web-client/pull/182 for a
+      // possible fix.
+      if (frame == 'Sky') {
+        layer.set_astronomical(true);
+      }
+
       layer.set_altUnit(1);
 
       wwt.layers[msg['id']] = layer;

--- a/pywwt/tests/test_layers.py
+++ b/pywwt/tests/test_layers.py
@@ -171,3 +171,41 @@ class TestLayers:
 
         with pytest.warns(UserWarning, match=expected_warning):
             layer.lon_att = 'flux'
+
+    def test_update_data(self):
+
+        self.table['flux'].unit = 'm'
+        layer = self.widget.layers.add_data_layer(table=self.table,
+                                                  lon_att='ra', lat_att='dec', alt_att='flux')
+
+        assert layer.lon_att == 'ra'
+        assert layer.lon_unit is u.deg
+        assert layer.lat_att == 'dec'
+        assert layer.alt_att == 'flux'
+        assert layer.alt_unit is u.m
+
+        # Replace with a table with the same column names but different units
+        # for the lon and alt
+        table = Table()
+        table['ra'] = [1, 2, 3] * u.hourangle
+        table['dec'] = [4, 5, 6]
+        table['flux'] = [2, 3, 4] * u.km
+        layer.update_data(table=table)
+
+        assert layer.lon_att == 'ra'
+        assert layer.lon_unit is u.hourangle
+        assert layer.lat_att == 'dec'
+        assert layer.alt_att == 'flux'
+        assert layer.alt_unit is u.km
+
+        # Replace with a table with different column names
+        table = Table()
+        table['a'] = [1, 2, 3] * u.deg
+        table['b'] = [4, 5, 6]
+        table['c'] = [2, 3, 4] * u.au
+        layer.update_data(table=table)
+
+        assert layer.lon_att == 'a'
+        assert layer.lon_unit is u.deg
+        assert layer.lat_att == 'b'
+        assert layer.alt_att == ''


### PR DESCRIPTION
This provides a way of updating layer data (rather than having to delete and re-create a layer). It also sets the astronomical mode when the frame is ``Sky`` and provides a way to set the opacity, although the first requires two changes to the web client SDK to work properly (https://github.com/WorldWideTelescope/wwt-web-client/pull/182 and https://github.com/WorldWideTelescope/wwt-web-client/pull/183) and the latter doesn't actually have any effect on the WWT side yet as WWT seems to ignore opacity.