### PR TITLE
Exposed a couple of features after SDK update

### DIFF
--- a/pywwt/nbextension/static/wwt.html
+++ b/pywwt/nbextension/static/wwt.html
@@ -72,18 +72,18 @@
         wwt.settings.set_locationAltitude(0.0)
         wwt.settings.set_locationLat(47.633)
         wwt.settings.set_locationLng(122.133333)
-        //wwt.settings.set_solarSystemCosmos(false) // in source, don't think works
-        wwt.settings.set_solarSystemLighting(true) // in source, NOW works
-        wwt.settings.set_solarSystemMilkyWay(true) // in source, works
-        //wwt.settings.set_solarSystemMultiRes(false) // in source, don't think works
-        wwt.settings.set_solarSystemOrbits(true) // in source, works
-        //wwt.settings.set_solarSystemOverlays(false) // in source, doesn't work
-        wwt.settings.set_solarSystemScale('1') // in source, works
-        //wwt.settings.set_solarSystemStars(false) // in source, doesn't work
-        //wwt.settings.set_solarSystemCMB(false); // in source, doesn't work
-        //wwt.settings.set_solarSystemMinorPlanets(false) // in source, doesn't work
-        //wwt.settings.set_solarSystemMinorOrbits(false) // in source, doesn't work
-        wwt.settings.set_solarSystemPlanets(true) // in source, works
+        //wwt.settings.set_solarSystemCosmos(false) // don't think works
+        wwt.settings.set_solarSystemLighting(true)
+        wwt.settings.set_solarSystemMilkyWay(true)
+        //wwt.settings.set_solarSystemMultiRes(false) // don't think works
+        wwt.settings.set_solarSystemOrbits(true)
+        //wwt.settings.set_solarSystemOverlays(false) // doesn't work
+        wwt.settings.set_solarSystemScale('1')
+        wwt.settings.set_solarSystemStars(true)
+        //wwt.settings.set_solarSystemCMB(false); // doesn't work?
+        //wwt.settings.set_solarSystemMinorPlanets(false) // overloads RAM
+        wwt.settings.set_solarSystemMinorOrbits(false)
+        wwt.settings.set_solarSystemPlanets(true)
 
         wwt_ready = 1;
 

--- a/pywwt/ss_proxy.py
+++ b/pywwt/ss_proxy.py
@@ -39,7 +39,7 @@ class SolarSystem(HasTraits):
                                 'background in solar system mode '
                                 '(`bool`)').tag(wwt='solarSystemMilkyWay')
     #multi_res = Bool(False, help='Whether to show the multi-resolution textures for planets where available (`bool`)').tag(wwt='solarSystemMultiRes') ###
-    #minor_orbits = Bool(False, help='Whether to show the orbits of minor planets in solar system mode (`bool`)').tag(wwt='solarSystemMinorOrbits') ###
+    minor_orbits = Bool(False, help='Whether to show the orbits of minor planets in solar system mode (`bool`)').tag(wwt='solarSystemMinorOrbits')
     #minor_planets = Bool(False, help='Whether to show minor planets in solar system mode (`bool`)').tag(wwt='solarSystemMinorPlanets') ###
     orbits = Bool(True,
                   help='Whether to show orbit paths when the solar system is '
@@ -50,7 +50,8 @@ class SolarSystem(HasTraits):
     scale = Int(1, help='Specifies how to scale objects\' size in solar '
                         'system mode, with 1 as actual size and 100 as the '
                         'maximum (`int`)').tag(wwt='solarSystemScale')
-    #stars = Bool(False, help='Whether to show background stars in solar system mode (`bool`)').tag(wwt='solarSystemStars') ###
+    stars = Bool(True, help='Whether to show background stars in solar system '
+                            'mode (`bool`)').tag(wwt='solarSystemStars')
 
     @validate('scale')
     def _validate_scale(self, proposal):


### PR DESCRIPTION
Namely, `set_solarSystemMinorOrbits` (orbit paths of non-featured moons, satellites, etc.) and `set_solarSystemStars` (background stars) in solar system mode. I also changed `solarSystemStars` to be on by default.

`set_solarSystemMinorPlanets` is also available now, but there are so many that it overloaded my RAM and crashed my session. In order to avoid this outcome for users, I've left it commented out.