### PR TITLE
Fix rendering of planet layers

### DIFF
--- a/pywwt/nbextension/static/wwt_json_api.js
+++ b/pywwt/nbextension/static/wwt_json_api.js
@@ -157,7 +157,11 @@ function wwt_apply_json_message(wwt, msg) {
       break;
 
     case 'set_viewer_mode':
+      // We need to set both the backround and foreground layers
+      // otherwise when changing to planet view, there are weird
+      // artifacts due to the fact one of the layes is the sky.
       wwt.setBackgroundImageByName(msg['mode']);
+      wwt.setForegroundImageByName(msg['mode']);
       break;
 
     case 'track_object':


### PR DESCRIPTION
We should make sure we set the foreground layer as well as the background layer when switching viewing mode (see https://github.com/WorldWideTelescope/wwt-web-client/issues/187)