### PR TITLE
Disable crosshairs by default

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,8 @@
 0.4.0 (unreleased)
 ------------------
 
+- Disable crosshairs by default. [#157]
+
 - Added ``pause_time`` and ``play_time`` for controlling time and make it
   possible to control the rate of passage of time. [#146, #152]
 

--- a/pywwt/core.py
+++ b/pywwt/core.py
@@ -109,7 +109,7 @@ class BaseWWTWidget(HasTraits):
     #constellation_pictures = Bool(False, help='Whether to show pictures of the constellations\' mythological representations (`bool`)').tag(wwt='showConstellationPictures')
     #constellation_labels = Bool(False, help='Whether to show labelss for constellations (`bool`)').tag(wwt='showConstellationLabels')
 
-    crosshairs = Bool(True, help='Whether to show crosshairs at the center of '
+    crosshairs = Bool(False, help='Whether to show crosshairs at the center of '
                                  'the field (`bool`)').tag(wwt='showCrosshairs')
     crosshairs_color = Color('white',
                              help='The color of the crosshairs '

--- a/pywwt/nbextension/static/wwt.html
+++ b/pywwt/nbextension/static/wwt.html
@@ -57,7 +57,7 @@
         wwt.settings.set_constellationBoundryColor('#0000ff')
         wwt.settings.set_constellationFigureColor('#ff0000')
         wwt.settings.set_constellationSelectionColor('#ffff00')
-        wwt.settings.set_showCrosshairs(true)
+        wwt.settings.set_showCrosshairs(false)
         wwt.settings.set_crosshairsColor('#ffffff')
         wwt.settings.set_showEcliptic(false)
         wwt.settings.set_showGrid(false)


### PR DESCRIPTION
I think things look prettier without the crosshair by default, and it's easy for people to add it if needed.