### PR TITLE
Set default earth map to daytime

### DIFF
--- a/pywwt/core.py
+++ b/pywwt/core.py
@@ -295,6 +295,9 @@ class BaseWWTWidget(HasTraits):
         solar_system_mode = '3D Solar System View'
 
         if mode in VIEW_MODES_2D:
+            if mode == 'earth':
+                # Switch to a daytime view of the earth
+                mode = 'Bing Maps Aerial'
             self._send_msg(event='set_viewer_mode', mode=mode)
             if mode == 'sky' or mode == 'panorama':
                 self.current_mode = mode

--- a/pywwt/layers.py
+++ b/pywwt/layers.py
@@ -121,7 +121,7 @@ class TableLayer(HasTraits):
     cmap_att = Unicode(help='The column to use for the colormap').tag(wwt='colorMapColumn')
 
     size_att = Unicode(help='The column to use for the size').tag(wwt='sizeColumn')
-    size_scale = Float(1, help='The factor by which to scale the size of the points').tag(wwt='scaleFactor')
+    size_scale = Float(10, help='The factor by which to scale the size of the points').tag(wwt='scaleFactor')
 
     color = Color('white', help='The color of the markers').tag(wwt='color')
     opacity = Float(1, help='The opacity of the markers').tag(wwt='opacity')
@@ -208,6 +208,11 @@ class TableLayer(HasTraits):
 
         self._initialize_layer()
 
+        # Force defaults
+        self._on_trait_change({'name': 'size_scale', 'new': self.size_scale})
+        self._on_trait_change({'name': 'color', 'new': self.color})
+        self._on_trait_change({'name': 'opacity', 'new': self.opacity})
+
         self.observe(self._on_trait_change, type='change')
 
         if any(key not in self.trait_names() for key in kwargs):
@@ -286,7 +291,6 @@ class TableLayer(HasTraits):
                 value = VALID_ALT_UNITS[self._check_alt_unit({'value': value})]
             elif changed['name'] == 'lon_unit':
                 value = VALID_LON_UNITS[self._check_lon_unit({'value': value})]
-            # TODO: need to generalize to not say table here
             self.parent._send_msg(event='table_layer_set',
                                   id=self.id,
                                   setting=wwt_name,


### PR DESCRIPTION
This partially addresses https://github.com/WorldWideTelescope/pywwt/issues/97

I say partially because for now we don't have a way to select the different earth maps available, which I suggest we focus on after this release. I think with this PR the default will at least be more sensible.