### PR TITLE
Further improvements to layers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,14 @@
 
 - Fixed issues with zooming using trackpad/scroll wheel. [#166]
 
+- Added support for customizing the layer marker type (``marker_type``), the
+  option to specify whether the marker size is absolute or relative to the
+  screen (``marker_scale``), and the option to show points on the far side of
+  an object (``far_side_visible``).
+
+- Fixed a bug that caused issues with the distance/altitude of points when not
+  centered on the Earth.
+
 0.4.1 (2018-12-23)
 ------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,10 +6,10 @@
 - Added support for customizing the layer marker type (``marker_type``), the
   option to specify whether the marker size is absolute or relative to the
   screen (``marker_scale``), and the option to show points on the far side of
-  an object (``far_side_visible``).
+  an object (``far_side_visible``). [#165]
 
 - Fixed a bug that caused issues with the distance/altitude of points when not
-  centered on the Earth.
+  centered on the Earth. [#165]
 
 0.4.1 (2018-12-23)
 ------------------

--- a/docs/layers.rst
+++ b/docs/layers.rst
@@ -127,6 +127,20 @@ or it can be set to be dependent on one of the columns with::
 
     >>> layer.cmap_att = 'depth'
 
+By default, the marker size stays constant relative to the screen, but this can
+be changed with::
+
+    >>> layer.marker_scale = 'world'
+
+To change it back to be relative to the screen, you can do::
+
+    >>> layer.marker_scale = 'screen'
+
+Finally, if you want to show all markers even if they are on the far side of
+a celestial object, you can use::
+
+    >>> layer.far_side_visible = True
+
 Listing layers and removing layers
 ----------------------------------
 

--- a/pywwt/layers.py
+++ b/pywwt/layers.py
@@ -279,6 +279,7 @@ class TableLayer(HasTraits):
         self._on_trait_change({'name': 'opacity', 'new': self.opacity})
         self._on_trait_change({'name': 'marker_type', 'new': self.marker_type})
         self._on_trait_change({'name': 'marker_scale', 'new': self.marker_scale})
+        self._on_trait_change({'name': 'far_side_visible', 'new': self.far_side_visible})
 
         self.observe(self._on_trait_change, type='change')
 

--- a/pywwt/layers.py
+++ b/pywwt/layers.py
@@ -12,7 +12,7 @@ from base64 import b64encode
 from astropy import units as u
 
 from traitlets import HasTraits, validate, observe
-from .traits import Any, Unicode, Float, Color
+from .traits import Any, Unicode, Float, Color, Bool
 
 __all__ = ['LayerManager', 'TableLayer']
 
@@ -173,6 +173,9 @@ class TableLayer(HasTraits):
     marker_type = Unicode('gaussian', help='The type of marker').tag(wwt='plotType')
     marker_scale = Unicode('screen', help='Whether the scale is defined in '
                            'world or pixel coordinates').tag(wwt='markerScale')
+
+    far_side_visible = Bool(False, help='Whether markers on the far side are '
+                            'visible').tag(wwt='showFarSide')
 
     # TODO: support:
     # xAxisColumn

--- a/pywwt/layers.py
+++ b/pywwt/layers.py
@@ -16,6 +16,10 @@ from .traits import Any, Unicode, Float, Color
 
 __all__ = ['LayerManager', 'TableLayer']
 
+VALID_FRAMES = ['sky', 'ecliptic', 'galactic', 'sun', 'mercury', 'venus',
+                'earth', 'mars', 'jupiter', 'saturn', 'uranus', 'neptune',
+                'pluto', 'moon', 'io', 'europa', 'ganymede', 'callisto']
+
 VALID_LON_UNITS = {u.deg: 'degrees',
                    u.hour: 'hours',
                    u.hourangle: 'hours'}
@@ -33,6 +37,10 @@ VALID_ALT_UNITS = {u.m: 'meters',
                    u.Mpc: 'megaParsecs'}
 
 VALID_ALT_TYPES = ['depth', 'altitude', 'distance', 'seaLevel', 'terrain']
+
+VALID_MARKER_TYPES = ['gaussian', 'point', 'circle', 'square', 'pushpin']
+
+VALID_MARKER_SCALES = ['screen', 'world']
 
 
 def guess_lon_lat_columns(colnames):
@@ -89,6 +97,12 @@ class LayerManager(object):
         Parameters
         ----------
         """
+
+        # Validate frame
+        if frame.lower() not in VALID_FRAMES:
+            raise ValueError('frame should be one of {0}'.format('/'.join(sorted(str(x) for x in VALID_FRAMES))))
+        frame = frame.capitalize()
+
         if table is not None:
             layer = TableLayer(self._parent, table=table, frame=frame, **kwargs)
         else:
@@ -156,6 +170,10 @@ class TableLayer(HasTraits):
     color = Color('white', help='The color of the markers').tag(wwt='color')
     opacity = Float(1, help='The opacity of the markers').tag(wwt='opacity')
 
+    marker_type = Unicode('gaussian', help='The type of marker').tag(wwt='plotType')
+    marker_scale = Unicode('screen', help='Whether the scale is defined in '
+                           'world or pixel coordinates').tag(wwt='markerScale')
+
     # TODO: support:
     # xAxisColumn
     # yAxisColumn
@@ -193,6 +211,20 @@ class TableLayer(HasTraits):
             return proposal['value']
         else:
             raise ValueError('alt_type should be one of {0}'.format('/'.join(str(x) for x in VALID_ALT_TYPES)))
+
+    @validate('marker_type')
+    def _check_marker_type(self, proposal):
+        if proposal['value'] in VALID_MARKER_TYPES:
+            return proposal['value']
+        else:
+            raise ValueError('marker_type should be one of {0}'.format('/'.join(str(x) for x in VALID_MARKER_TYPES)))
+
+    @validate('marker_scale')
+    def _check_marker_scale(self, proposal):
+        if proposal['value'] in VALID_MARKER_SCALES:
+            return proposal['value']
+        else:
+            raise ValueError('marker_scale should be one of {0}'.format('/'.join(str(x) for x in VALID_MARKER_SCALES)))
 
     @observe('alt_att')
     def _on_alt_att_change(self, *value):
@@ -242,6 +274,8 @@ class TableLayer(HasTraits):
         self._on_trait_change({'name': 'size_scale', 'new': self.size_scale})
         self._on_trait_change({'name': 'color', 'new': self.color})
         self._on_trait_change({'name': 'opacity', 'new': self.opacity})
+        self._on_trait_change({'name': 'marker_type', 'new': self.marker_type})
+        self._on_trait_change({'name': 'marker_scale', 'new': self.marker_scale})
 
         self.observe(self._on_trait_change, type='change')
 

--- a/pywwt/nbextension/static/wwt_json_api.js
+++ b/pywwt/nbextension/static/wwt_json_api.js
@@ -3,6 +3,25 @@
 // we can then use it for both the Jupyter widget and other front-ends such
 // as the Qt one.
 
+
+var ReferenceFramesRadius = {
+  Sun: 696000000,
+  Mercury: 2439700,
+  Venus: 6051800,
+  Earth: 6371000,
+  Mars: 3390000,
+  Jupiter: 69911000,
+  Saturn: 58232000,
+  Uranus: 25362000,
+  Neptune: 24622000,
+  Pluto: 1161000,
+  Moon: 1737100,
+  Io: 1821500,
+  Europa: 1561000,
+  Ganymede: 2631200,
+  Callisto: 2410300
+};
+
 function wwt_apply_json_message(wwt, msg) {
 
   if (!wwt.hasOwnProperty('annotations')) {
@@ -179,6 +198,13 @@ function wwt_apply_json_message(wwt, msg) {
       layer = wwtlib.LayerManager.createSpreadsheetLayer(frame, "PyWWT Layer", csv);
       layer.set_referenceFrame(frame);
 
+      // FIXME: at the moment WWT incorrectly sets the mean radius of the object
+      // in the frame to that of the Earth, so we need to override this here.
+      radius = ReferenceFramesRadius[frame];
+      if (radius != undefined) {
+        layer._meanRadius$1 = radius;
+      }
+
       // FIXME: for now, this doesn't have any effect because WWT should add a 180
       // degree offset but it doesn't - see
       // https://github.com/WorldWideTelescope/wwt-web-client/pull/182 for a
@@ -219,6 +245,10 @@ function wwt_apply_json_message(wwt, msg) {
         value = wwtlib.RAUnits[msg['value']];
       } else if(name == 'altType') {
         value = wwtlib.AltTypes[msg['value']];
+      } else if(name == 'plotType') {
+        value = wwtlib.PlotTypes[msg['value']];
+      } else if(name == 'markerScale') {
+        value = wwtlib.MarkerScales[msg['value']];
       } else {
         value = msg['value']
       }


### PR DESCRIPTION
This implements the ability to specify whether marker size is relative to the screen or the world coordinates, as well the the marker type (although see https://github.com/WorldWideTelescope/wwt-web-client/issues/191 for a description of issues related to that).

This also adds a workaround for https://github.com/WorldWideTelescope/wwt-web-client/issues/189 which means that plotting relative to e.g. the Sun and bodies other than the Earth will work correctly when the altitude/distance is provided.

Finally, this exposes the option to show/hide points on the far side of an object (see https://github.com/WorldWideTelescope/wwt-web-client/issues/190 for what I think is an issue with the default setting of ``False``).