### PR TITLE
Update Jupyter Lab instructions and add release docs

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,52 @@
+Releasing
+=========
+
+To do a release, first edit the ``CHANGES.rst`` file to include the date of the
+release after the version number, and make sure the changelog is up to date.
+
+Then edit the following files to update the version numbers:
+
+* ``docs/conf.py``
+* ``pywwt/_version.py`` (make sure the string in the tuple is set to ``final``)
+* ``lib/wwt.js``
+* ``package.json``
+* ``pywwt/jupyter.py``
+
+At this point, commit all changes and use the following for the commit message::
+
+    Preparing release v<version>
+
+Now make sure there are no temporary files in the repository::
+
+    git clean -fxd
+
+and build the release files::
+
+    python setup.py sdist bdist_wheel --universal
+
+Go inside the ``dist`` directory, and you should see a tar file and a wheel.
+At this point, if you wish, you can untar the tar file and try installing and
+testing the installation. Once you are satisfied that the release is good
+you can upload the release using twine::
+
+    twine upload pywwt-0.5.1.tar.gz pywwt-0.5.1-py2.py3-none-any.whl
+
+If you don't have twine installed, you can get it with ``pip install twine``.
+
+Next, go back to the root of the repository and publish the package to npm with::
+
+    git clean -fxd
+    npm install
+    npm publish
+
+At this point, you can tag the release with::
+
+    git tag -m v<version> v<version>
+
+If you have PGP keys set up, you can sign the tag by also including ``-s``.
+
+Now change the versions in the files listed above to the next version - and for
+the ``pywwt/_version.py`` file, change ``final`` to ``dev``. Commit the changes
+with::
+
+    Back to development: v<next_version>

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -22,11 +22,7 @@ release of pywwt using::
 This will automatically install pywwt, its `dependencies <Dependencies>`_, and
 will enable the Jupyter extension.
 
-If you want to use WWT inside Jupyter Lab, you may need to also run::
-
-    jupyter labextension install @jupyter-widgets/jupyterlab-manager
-
-if you have never used widgets in Jupyter Lab before.
+If you want to use WWT inside Jupyter Lab, see `Using Jupyter Lab`_.
 
 Installing pywwt with pip
 -------------------------
@@ -40,11 +36,20 @@ If you want to use the Qt widget, you will need to install
 `PyQt <https://riverbankcomputing.com/software/pyqt/intro>`_ or
 `PySide <https://wiki.qt.io/PySide>`_ separately.
 
-If you want to use WWT inside Jupyter Lab, you may need to also run::
+If you want to use WWT inside Jupyter Lab, see `Using Jupyter Lab`_.
+
+Using Jupyter Lab
+-----------------
+
+If you want to use the PyWWT widget inside Jupyter Lab, and you haven't used it
+or other widgets before in Jupyter Lab, you may need to also run::
 
     jupyter labextension install @jupyter-widgets/jupyterlab-manager
 
-if you have never used widgets in Jupyter Lab before.
+In addition, while Jupyter Lab should offer to do a re-build when it detects
+a new version of PyWWT, you can also do a build manually with::
+
+    jupyter lab build
 
 Dependencies
 ------------


### PR DESCRIPTION
This adds a mention of ``jupyter lab build`` as suggested by @pkgw in https://github.com/WorldWideTelescope/pywwt/pull/170, and also adds initial docs describing the release workflow (I'll use this next time I go through a release and will update it if needed).