### PR TITLE
Expose option to control large-scale SDSS data

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,9 +7,9 @@
 ------------------
 
 - Exposed option to turn off large-scale SDSS data in 3D mode, improving
-  performance.
+  performance. [#176]
 
-- Make sure default altitude type is set correctly.
+- Make sure default altitude type is set correctly. [#176]
 
 0.5.2 (2019-01-08)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,15 @@
 
 - No changes yet.
 
-0.5.2 (unreleased)
+0.5.3 (unreleased)
+------------------
+
+- Exposed option to turn off large-scale SDSS data in 3D mode, improving
+  performance.
+
+- Make sure default altitude type is set correctly.
+
+0.5.2 (2019-01-08)
 ------------------
 
 - Added instructions for using Jupyter Lab. [#170]

--- a/pywwt/layers.py
+++ b/pywwt/layers.py
@@ -274,6 +274,7 @@ class TableLayer(HasTraits):
         self._initialize_layer()
 
         # Force defaults
+        self._on_trait_change({'name': 'alt_type', 'new': self.alt_type})
         self._on_trait_change({'name': 'size_scale', 'new': self.size_scale})
         self._on_trait_change({'name': 'color', 'new': self.color})
         self._on_trait_change({'name': 'opacity', 'new': self.opacity})

--- a/pywwt/nbextension/static/wwt.html
+++ b/pywwt/nbextension/static/wwt.html
@@ -73,7 +73,7 @@
         wwt.settings.set_locationAltitude(0.0)
         wwt.settings.set_locationLat(47.633)
         wwt.settings.set_locationLng(122.133333)
-        wwt.settings.set_solarSystemCosmos(false)
+        wwt.settings.set_solarSystemCosmos(true)
         wwt.settings.set_solarSystemLighting(true)
         wwt.settings.set_solarSystemMilkyWay(true)
         //wwt.settings.set_solarSystemMultiRes(false) // don't think works

--- a/pywwt/nbextension/static/wwt.html
+++ b/pywwt/nbextension/static/wwt.html
@@ -73,7 +73,7 @@
         wwt.settings.set_locationAltitude(0.0)
         wwt.settings.set_locationLat(47.633)
         wwt.settings.set_locationLng(122.133333)
-        //wwt.settings.set_solarSystemCosmos(false) // don't think works
+        wwt.settings.set_solarSystemCosmos(false)
         wwt.settings.set_solarSystemLighting(true)
         wwt.settings.set_solarSystemMilkyWay(true)
         //wwt.settings.set_solarSystemMultiRes(false) // don't think works

--- a/pywwt/solar_system.py
+++ b/pywwt/solar_system.py
@@ -34,7 +34,7 @@ class SolarSystem(HasTraits):
                                 value=new_value)
 
     #cmb = Bool(False, help='Whether to show the cosmic microwave background in solar system mode (`bool`)').tag(wwt='solarSystemCMB') ###
-    cosmos = Bool(False, help='Whether to show data from the SDSS survey (`bool`)').tag(wwt='solarSystemCosmos') ###
+    cosmos = Bool(True, help='Whether to show data from the SDSS survey (`bool`)').tag(wwt='solarSystemCosmos') ###
     #display = Bool(False, help='Whether to show the solar system while in solar system mode (`bool`)').tag(wwt='solarSystemOverlays') ###
     lighting = Bool(True,
                     help='Whether to show the lighting effect of the Sun on the'

--- a/pywwt/solar_system.py
+++ b/pywwt/solar_system.py
@@ -34,7 +34,7 @@ class SolarSystem(HasTraits):
                                 value=new_value)
 
     #cmb = Bool(False, help='Whether to show the cosmic microwave background in solar system mode (`bool`)').tag(wwt='solarSystemCMB') ###
-    #cosmos = Bool(False, help='Whether to show data from the SDSS Cosmos data set (`bool`)').tag(wwt='solarSystemCosmos') ###
+    cosmos = Bool(False, help='Whether to show data from the SDSS survey (`bool`)').tag(wwt='solarSystemCosmos') ###
     #display = Bool(False, help='Whether to show the solar system while in solar system mode (`bool`)').tag(wwt='solarSystemOverlays') ###
     lighting = Bool(True,
                     help='Whether to show the lighting effect of the Sun on the'


### PR DESCRIPTION
This exposes the option to turn the large-scale SDSS data on/off since this now works in the SDK. I'm going to include it in a small bug fix release because it currently causes the performance to be quite poor when in Milky Way mode, and I need a way to turn it off in glue.