### PR TITLE
Added auto-zoom to solar_system.track_object

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -46,6 +46,9 @@
 - Implement support for color-coding and scaling points in layers according
   to table attributes. [#183]
 
+- Edited solar system ``track_object`` attribute so the viewer automatically
+  zooms to a field of view where the object is actually visible [#187]
+
 - Removed ``load_fits_data`` and added ``layers.add_image_layer`` instead,
   which provides control over the image stretch, and renamed
   ``layers.add_data_layer`` to ``layers.add_table_layer``. [#188, #201]

--- a/pywwt/nbextension/static/wwt_json_api.js
+++ b/pywwt/nbextension/static/wwt_json_api.js
@@ -184,33 +184,36 @@ function wwt_apply_json_message(wwt, msg) {
       wwt.setBackgroundImageByName(msg['mode']);
       wwt.setForegroundImageByName(msg['mode']);
       break;
-/*
-    case 'track_object':
-      wwtlib.WWTControl.singleton.renderContext.set_solarSystemTrack(msg['code']);
-      break;
-*/
+
     case 'track_and_zoom':
+
       var object = msg['obj'];
+      var instant = msg['inst'];
+
+      // Collect the arguments necessary to create a Place object
       var ra = wwt.getRA();
       var dec = wwt.getDec();
       var classification = wwtlib.Classification.solarSystem;
-      var constellation = wwtlib.Place._constellation;
+      var constellation;
       var imageType = wwtlib.ImageSetType.sky;
       //var imageType = wwtlib.ImageSetType.solarSystem;
       var scale = wwt.settings.get_solarSystemScale();
       var zoom; //= (.02 * scale + .08) / msg['zoom'];
-      // if imageType == wwtlib.ImageSetType.solarSystem, we need the equation above
-      // else, zoom is pre-set in gotoTarget if imageType == wwtlib.ImageSetType.sky
+      // if imageType == wwtlib.ImageSetType.solarSystem, use the equation
+      // elif imageType == wwtlib.ImageSetType.sky, gotoTarget pre-sets zoom
 
-      var place = wwtlib.Place.create(object, ra, dec, classification, 
+      // Create the Place object and focus it on the object in question
+      var place = wwtlib.Place.create(object, ra * 15, dec, classification,
                                       constellation, imageType, zoom);
       place.set_target(wwtlib.Planets.getPlanetIDFromName(object));
 
+      // Go to the place that was created (if not the Sun)
+      // Else, use the standard, Sun-centered method of centering on coords
       if (object != 'Sun') {
-        wwtlib.WWTControl.singleton.gotoTarget(place, false, msg['inst'], true);
+        wwtlib.WWTControl.singleton.gotoTarget(place, false, instant, true);
       }
       else {
-        wwt.gotoRaDecZoom(ra, dec, .00221*scale + .00552, msg['inst']);
+        wwt.gotoRaDecZoom(ra * 15, dec, .00221*scale + .00552, msg['inst']);
       }
 
       break;

--- a/pywwt/nbextension/static/wwt_json_api.js
+++ b/pywwt/nbextension/static/wwt_json_api.js
@@ -190,24 +190,28 @@ function wwt_apply_json_message(wwt, msg) {
       var object = msg['obj'];
       var instant = msg['inst'];
 
-      // Collect the arguments necessary to create a Place object
+      // First, collect the arguments necessary to create a Place object
+
+      // (record current ra/dec so they're preserved if the object is the Sun)
       var ra = wwt.getRA();
       var dec = wwt.getDec();
+      // (create other args for Place.create(), keeping unecessary ones blank)
       var classification = wwtlib.Classification.solarSystem;
       var constellation;
       var imageType = wwtlib.ImageSetType.sky;
-      //var imageType = wwtlib.ImageSetType.solarSystem;
       var scale = wwt.settings.get_solarSystemScale();
-      var zoom; //= (.02 * scale + .08) / msg['zoom'];
-      // if imageType == wwtlib.ImageSetType.solarSystem, use the equation
-      // elif imageType == wwtlib.ImageSetType.sky, gotoTarget pre-sets zoom
+      var zoom;
 
-      // Create the Place object and focus it on the object in question
+      // (when #177 is solved, try imageType = wwtlib.ImageSetType.solarSystem
+      // and zoom = (.02 * scale + .08) / msg['zoom'] for more flexibility in
+      // assigning ra/dec to non-Sun objects)
+
+      // Next, create the Place object and focus it on the object in question
       var place = wwtlib.Place.create(object, ra * 15, dec, classification,
                                       constellation, imageType, zoom);
       place.set_target(wwtlib.Planets.getPlanetIDFromName(object));
 
-      // Go to the place that was created (if not the Sun)
+      // Finally, if not the Sun, go to the place that was created
       // Else, use the standard, Sun-centered method of centering on coords
       if (object != 'Sun') {
         wwtlib.WWTControl.singleton.gotoTarget(place, false, instant, true);

--- a/pywwt/nbextension/static/wwt_json_api.js
+++ b/pywwt/nbextension/static/wwt_json_api.js
@@ -184,9 +184,35 @@ function wwt_apply_json_message(wwt, msg) {
       wwt.setBackgroundImageByName(msg['mode']);
       wwt.setForegroundImageByName(msg['mode']);
       break;
-
+/*
     case 'track_object':
       wwtlib.WWTControl.singleton.renderContext.set_solarSystemTrack(msg['code']);
+      break;
+*/
+    case 'track_and_zoom':
+      var object = msg['obj'];
+      var ra = wwt.getRA();
+      var dec = wwt.getDec();
+      var classification = wwtlib.Classification.solarSystem;
+      var constellation = wwtlib.Place._constellation;
+      var imageType = wwtlib.ImageSetType.sky;
+      //var imageType = wwtlib.ImageSetType.solarSystem;
+      var scale = wwt.settings.get_solarSystemScale();
+      var zoom; //= (.02 * scale + .08) / msg['zoom'];
+      // if imageType == wwtlib.ImageSetType.solarSystem, we need the equation above
+      // else, zoom is pre-set in gotoTarget if imageType == wwtlib.ImageSetType.sky
+
+      var place = wwtlib.Place.create(object, ra, dec, classification, 
+                                      constellation, imageType, zoom);
+      place.set_target(wwtlib.Planets.getPlanetIDFromName(object));
+
+      if (object != 'Sun') {
+        wwtlib.WWTControl.singleton.gotoTarget(place, false, msg['inst'], true);
+      }
+      else {
+        wwt.gotoRaDecZoom(ra, dec, .00221*scale + .00552, msg['inst']);
+      }
+
       break;
 
     case 'image_layer_create':

--- a/pywwt/solar_system.py
+++ b/pywwt/solar_system.py
@@ -3,6 +3,12 @@ from traitlets import HasTraits, validate
 
 from .traits import Bool, Int
 
+AVAILABLE_OBJECTS = ['Sky', 'Sun', 'Mercury', 'Venus', 'Earth', 'Moon', 'Mars',
+                     'Jupiter', 'Callisto', 'Europa', 'Ganymede', 'Io',
+                     'Saturn', 'Uranus', 'Neptune', 'Pluto', 'Callistoshadow',
+                     'Europashadow', 'Ganymedeshadow', 'Ioshadow',
+                     'Suneclipsed']
+
 __all__ = ['SolarSystem']
 
 
@@ -78,38 +84,9 @@ class SolarSystem(HasTraits):
         """
         obj = (obj.lower()).capitalize()
 
-        # find what type of body obj is for proper scaling in viewer
-        #sun = 1; gas = 20; rock = 200 # if imageSetType == solarSystem
-
-        '''mappings = {'Sun': 0, 'Mercury': 1, 'Venus': 2, 'Mars': 3, 'Jupiter': 4,
-                    'Saturn': 5, 'Uranus': 6, 'Neptune': 7, 'Pluto': 8,
-                    'Moon': 9, 'io': 10, 'Europa': 11, 'Ganymede': 12,
-                    'Callisto': 13, 'Ioshadow': 14, 'Europashadow': 15,
-                    'Ganymedeshadow': 16, 'Callistoshadow': 17,
-                    'Suneclipsed': 18, 'Earth': 19}'''
-
-        '''zooms = {'Sun': sun, 'Mercury': rock, 'Venus': rock, 'Mars': rock,
-                 'Jupiter': gas, 'Saturn': gas, 'Uranus': gas, 'Neptune': gas,
-                 'Pluto': rock, 'Moon': rock, 'Io': rock, 'Europa': rock,
-                 'Ganymede': rock, 'Callisto': rock, 'Ioshadow': rock,
-                 'Europashadow': rock, 'Ganymedeshadow': rock,
-                 'Callistoshadow': rock, 'Suneclipsed': sun, 'Earth': rock}'''
-
-        available = ['Sky', 'Sun', 'Mercury', 'Venus', 'Earth', 'Moon', 'Mars',
-                     'Jupiter', 'Callisto', 'Europa', 'Ganymede', 'Io',
-                     'Saturn', 'Uranus', 'Neptune', 'Pluto', 'Callistoshadow',
-                     'Europashadow', 'Ganymedeshadow', 'Ioshadow',
-                     'Suneclipsed']
-
-        if obj in available:
+        if obj in AVAILABLE_OBJECTS:
             self.base_widget._send_msg(event='track_and_zoom',
                                        obj=obj, inst=instant)
-
-            # if imageSetType == solarSystem
-            #self.base_widget._send_msg(event='track_and_zoom', obj=obj, zoom=zooms[obj], inst=instant)
-
-            # old
-            #self.base_widget._send_msg(event='track_object', code=mappings[obj])
         else:
             raise ValueError('the given object cannot be tracked')
 

--- a/pywwt/solar_system.py
+++ b/pywwt/solar_system.py
@@ -65,7 +65,7 @@ class SolarSystem(HasTraits):
         else:
             raise ValueError('scale takes integers from 1-100')
 
-    def track_object(self, obj):
+    def track_object(self, obj, instant=False):
         """
         Focus the viewer on a particular object while in solar system mode.
         Available objects include the Sun, the planets, the Moon, Jupiter's
@@ -76,17 +76,40 @@ class SolarSystem(HasTraits):
         obj : `str`
             The desired solar system object.
         """
-        obj = obj.lower()
-        mappings = {'sun': 0, 'mercury': 1, 'venus': 2, 'mars': 3, 'jupiter': 4,
-                    'saturn': 5, 'uranus': 6, 'neptune': 7, 'pluto': 8,
-                    'moon': 9, 'io': 10, 'europa': 11, 'ganymede': 12,
-                    'callisto': 13, 'ioshadow': 14, 'europashadow': 15,
-                    'ganymedeshadow': 16, 'callistoshadow': 17,
-                    'suneclipsed': 18, 'earth': 19}
+        obj = (obj.lower()).capitalize()
 
-        if obj in mappings:
-            self.base_widget._send_msg(event='track_object', code=mappings[obj])
-            self._tracked_obj_id = mappings[obj]
+        # find what type of body obj is for proper scaling in viewer
+        #sun = 1; gas = 20; rock = 200 # if imageSetType == solarSystem
+
+        '''mappings = {'Sun': 0, 'Mercury': 1, 'Venus': 2, 'Mars': 3, 'Jupiter': 4,
+                    'Saturn': 5, 'Uranus': 6, 'Neptune': 7, 'Pluto': 8,
+                    'Moon': 9, 'io': 10, 'Europa': 11, 'Ganymede': 12,
+                    'Callisto': 13, 'Ioshadow': 14, 'Europashadow': 15,
+                    'Ganymedeshadow': 16, 'Callistoshadow': 17,
+                    'Suneclipsed': 18, 'Earth': 19}'''
+
+        '''zooms = {'Sun': sun, 'Mercury': rock, 'Venus': rock, 'Mars': rock,
+                 'Jupiter': gas, 'Saturn': gas, 'Uranus': gas, 'Neptune': gas,
+                 'Pluto': rock, 'Moon': rock, 'Io': rock, 'Europa': rock,
+                 'Ganymede': rock, 'Callisto': rock, 'Ioshadow': rock,
+                 'Europashadow': rock, 'Ganymedeshadow': rock,
+                 'Callistoshadow': rock, 'Suneclipsed': sun, 'Earth': rock}'''
+
+        available = ['Sky', 'Sun', 'Mercury', 'Venus', 'Earth', 'Moon', 'Mars',
+                     'Jupiter', 'Callisto', 'Europa', 'Ganymede', 'Io',
+                     'Saturn', 'Uranus', 'Neptune', 'Pluto', 'Callistoshadow',
+                     'Europashadow', 'Ganymedeshadow', 'Ioshadow',
+                     'Suneclipsed']
+
+        if obj in available:
+            self.base_widget._send_msg(event='track_and_zoom',
+                                       obj=obj, inst=instant)
+
+            # if imageSetType == solarSystem
+            #self.base_widget._send_msg(event='track_and_zoom', obj=obj, zoom=zooms[obj], inst=instant)
+
+            # old
+            #self.base_widget._send_msg(event='track_object', code=mappings[obj])
         else:
             raise ValueError('the given object cannot be tracked')
 


### PR DESCRIPTION
Addresses #123.  The changes in the first commit fix the issues I was having with both animated transitions and selecting Earth.

I use `gotoRaDecZoom` for the Sun since it the zoom levels for `gotoTarget` appear to be immutable, and I thought it made the Sun a little small compared to how the other planets and moons appear. `gotoTarget` appears to default to the behavior of the `gotoRaDecZoom` when the target is the Sun, anyway, so using `gotoRaDecZoom` gains you direct control over the zoom level.

If this is all good and there are no more changes to make, I can delete the comments before we merge this PR.