### PR TITLE
Fix pywwt on `notebook >=5.7.6`

### DIFF
--- a/pywwt/jupyter_server.py
+++ b/pywwt/jupyter_server.py
@@ -1,5 +1,6 @@
 import os
 import json
+import mimetypes
 from hashlib import md5
 from tornado import web
 from notebook.utils import url_path_join
@@ -32,6 +33,9 @@ class WWTFileHandler(IPythonHandler):
                 path = config['paths'][filename]
             else:
                 raise web.HTTPError(404)
+
+        # Do our best to set an appropriate Content-Type.
+        self.set_header('Content-Type', mimetypes.guess_type(filename)[0])
 
         with open(path, 'rb') as f:
             content = f.read()


### PR DESCRIPTION
Version 5.7.6 of the Jupyter notebook module adds a new security feature related to the HTTP content types (https://github.com/jupyter/notebook/issues/4467#issuecomment-471353499). It breaks pywwt because pywwt has not been returning valid MIME types (AKA content types) from its internal Jupyter server.

From looking at the main `notebook` implementation, it seems that the correct approach is to use the `mimetypes` module to get the right value to put in the Content-Type header, so let's go ahead and do that.

Closes #191.