### PR TITLE
pywwt/layers.py: have `add_data_layer()` fallback to `add_table_layer()`

### DIFF
--- a/pywwt/layers.py
+++ b/pywwt/layers.py
@@ -166,7 +166,7 @@ class LayerManager(object):
         Deprecated, use ``add_table_layer`` instead.
         """
         warnings.warn('add_data_layer has been deprecated, use add_table_layer '
-                      'instead', UserWarning)
+                      'instead', DeprecationWarning)
         return self.add_table_layer(*args, **kwargs)
 
     def _add_layer(self, layer):

--- a/pywwt/layers.py
+++ b/pywwt/layers.py
@@ -167,6 +167,7 @@ class LayerManager(object):
         """
         warnings.warn('add_data_layer has been deprecated, use add_table_layer '
                       'instead', UserWarning)
+        return self.add_table_layer(*args, **kwargs)
 
     def _add_layer(self, layer):
         if layer in self._layers:

--- a/pywwt/tests/test_layers.py
+++ b/pywwt/tests/test_layers.py
@@ -212,6 +212,25 @@ class TestLayers:
         assert layer.lat_att == 'b'
         assert layer.alt_att == ''
 
+    def test_deprecated_api_call(self, capsys):
+        """For the time being, test that the deprecated name for this function still
+        works, but issues a warning
+
+        """
+        import warnings
+
+        assert len(self.client.layers) == 0
+        assert str(self.client.layers) == 'Layer manager with no layers'
+
+        with warnings.catch_warnings(record=True) as w:
+            layer1 = self.client.layers.add_data_layer(table=self.table)
+
+        assert len(self.client.layers) == 1
+        assert str(self.client.layers) == ('Layer manager with 1 layers:\n\n'
+                                           '  [0]: TableLayer with 3 markers\n')
+        assert len(w) == 1
+        assert issubclass(w[-1].category, DeprecationWarning)
+
 
 CASES = [[('flux', 'dec', 'ra'), ('ra', 'dec')],
          [('mass', 'lat', 'lon'), ('lon', 'lat')],


### PR DESCRIPTION
The method name `add_data_layer()` may be deprecated, but to maintain compatibility we should still actually do something. So, fall back to `add_table_layer()` when called. This fixes glue-wwt, which hasn't been updated to the new API yet.