### PR TITLE
Pass drag and drop up to parent in Qt widget

### DIFF
--- a/pywwt/qt.py
+++ b/pywwt/qt.py
@@ -123,7 +123,7 @@ class WWTQtWidget(QtWidgets.QWidget):
 
         super(WWTQtWidget, self).__init__(parent=parent)
 
-        self.web = QWebEngineView()
+        self.web = WWTWebEngineView()
         self.page = WWTQWebEnginePage()
         self.page.setView(self.web)
         self.web.setPage(self.page)

--- a/pywwt/qt.py
+++ b/pywwt/qt.py
@@ -30,6 +30,25 @@ with open(WWT_HTML_FILE) as f:
     WWT_HTML = f.read()
 
 
+class WWTWebEngineView(QWebEngineView):
+
+    # Pass drag and drop events back up to the parent
+    # as this is needed for cases where applications
+    # embed a PyWWT Qt widget.
+
+    def dragEnterEvent(self, event):
+        return self.parent().dragEnterEvent(event)
+
+    def dragMoveEvent(self, event):
+        return self.parent().dragMoveEvent(event)
+
+    def dragLeaveEvent(self, event):
+        return self.parent().dragLeaveEvent(event)
+
+    def dropEvent(self, event):
+        return self.parent().dropEvent(event)
+
+
 class WWTQWebEnginePage(QWebEnginePage):
     """
     Subclass of QWebEnginePage that can check when WWT is ready for
@@ -139,6 +158,18 @@ class WWTQtWidget(QtWidgets.QWidget):
         else:
             logger.debug('Caching javascript: %s' % js)
             self._js_queue += js + '\n'
+
+    def dragEnterEvent(self, event):
+        return self.parent().dragEnterEvent(event)
+
+    def dragMoveEvent(self, event):
+        return self.parent().dragMoveEvent(event)
+
+    def dragLeaveEvent(self, event):
+        return self.parent().dragLeaveEvent(event)
+
+    def dropEvent(self, event):
+        return self.parent().dropEvent(event)
 
 
 class WWTQtClient(BaseWWTWidget):

--- a/pywwt/qt.py
+++ b/pywwt/qt.py
@@ -37,16 +37,28 @@ class WWTWebEngineView(QWebEngineView):
     # embed a PyWWT Qt widget.
 
     def dragEnterEvent(self, event):
-        return self.parent().dragEnterEvent(event)
+        if self.parent() is None:
+            super(WWTWebEngineView, self).dragEnterEvent(event)
+        else:
+            return self.parent().dragEnterEvent(event)
 
     def dragMoveEvent(self, event):
-        return self.parent().dragMoveEvent(event)
+        if self.parent() is None:
+            super(WWTWebEngineView, self).dragMoveEvent(event)
+        else:
+            return self.parent().dragMoveEvent(event)
 
     def dragLeaveEvent(self, event):
-        return self.parent().dragLeaveEvent(event)
+        if self.parent() is None:
+            super(WWTWebEngineView, self).dragLeaveEvent(event)
+        else:
+            return self.parent().dragLeaveEvent(event)
 
     def dropEvent(self, event):
-        return self.parent().dropEvent(event)
+        if self.parent() is None:
+            super(WWTWebEngineView, self).dropEvent(event)
+        else:
+            return self.parent().dropEvent(event)
 
 
 class WWTQWebEnginePage(QWebEnginePage):
@@ -160,16 +172,28 @@ class WWTQtWidget(QtWidgets.QWidget):
             self._js_queue += js + '\n'
 
     def dragEnterEvent(self, event):
-        return self.parent().dragEnterEvent(event)
+        if self.parent() is None:
+            super(WWTQtWidget, self).dragEnterEvent(event)
+        else:
+            return self.parent().dragEnterEvent(event)
 
     def dragMoveEvent(self, event):
-        return self.parent().dragMoveEvent(event)
+        if self.parent() is None:
+            super(WWTQtWidget, self).dragMoveEvent(event)
+        else:
+            return self.parent().dragMoveEvent(event)
 
     def dragLeaveEvent(self, event):
-        return self.parent().dragLeaveEvent(event)
+        if self.parent() is None:
+            super(WWTQtWidget, self).dragLeaveEvent(event)
+        else:
+            return self.parent().dragLeaveEvent(event)
 
     def dropEvent(self, event):
-        return self.parent().dropEvent(event)
+        if self.parent() is None:
+            super(WWTQtWidget, self).dropEvent(event)
+        else:
+            return self.parent().dropEvent(event)
 
 
 class WWTQtClient(BaseWWTWidget):


### PR DESCRIPTION
This is needed for glue and any other application that might want to embed the Qt WWT widget - basically this provides a way for the parent application to define custom drag and drop behavior.