### PR TITLE
Fix Table Layer issue in Windows

### DIFF
--- a/pywwt/layers.py
+++ b/pywwt/layers.py
@@ -103,7 +103,7 @@ def csv_table_win_newline(table):
     table.write(s, format='ascii.basic', delimiter=',', comment=False)
     s.seek(0)
     #Replace single \r or \n characters with \r\n
-    return re.sub(r"(?<=[^\r\n])(\r|\n)(?=[^\r\n])", "\r\n", s.read())
+    return re.sub(r"(?<![\r\n])(\r|\n)(?![\r\n])", "\r\n", s.read())
 
 
 class LayerManager(object):

--- a/pywwt/layers.py
+++ b/pywwt/layers.py
@@ -2,6 +2,8 @@ import sys
 import uuid
 import tempfile
 
+import re
+
 if sys.version_info[0] == 2:  # noqa
     from io import BytesIO as StringIO
 else:
@@ -92,6 +94,16 @@ def pick_unit_if_available(unit, valid_units):
         if unit == valid_unit:
             return valid_unit
     return unit
+
+def csv_table_win_newline(table):
+    '''
+    Helper funcion to get Astropy tables as ASCII CSV with Windows line endings
+    '''
+    s = StringIO()
+    table.write(s, format='ascii.basic', delimiter=',', comment=False)
+    s.seek(0)
+    #Replace single \r or \n characters with \r\n
+    return re.sub(r"(?<=[^\r\n])(\r|\n)(?=[^\r\n])", "\r\n", s.read())
 
 
 class LayerManager(object):
@@ -483,13 +495,7 @@ class TableLayer(HasTraits):
         # TODO: We need to make sure that the table has ra/dec columns since
         # WWT absolutely needs that upon creation.
 
-        s = StringIO()
-        self.table.write(s, format='ascii.basic', delimiter=',', comment=False)
-        s.seek(0)
-
-        # Enforce Windows line endings
-        # TODO: check if this needs to be different on Windows
-        csv = s.read().replace('\n', '\r\n')
+        csv = csv_table_win_newline(self.table)
 
         return b64encode(csv.encode('ascii', errors='replace')).decode('ascii')
 

--- a/pywwt/layers.py
+++ b/pywwt/layers.py
@@ -97,7 +97,7 @@ def pick_unit_if_available(unit, valid_units):
 
 def csv_table_win_newline(table):
     '''
-    Helper funcion to get Astropy tables as ASCII CSV with Windows line endings
+    Helper function to get Astropy tables as ASCII CSV with Windows line endings
     '''
     s = StringIO()
     table.write(s, format='ascii.basic', delimiter=',', comment=False)

--- a/pywwt/tests/test_layers.py
+++ b/pywwt/tests/test_layers.py
@@ -11,7 +11,7 @@ from astropy.coordinates import SkyCoord
 from .test_qt_widget import assert_widget_image
 
 from ..core import BaseWWTWidget
-from ..layers import TableLayer, guess_lon_lat_columns
+from ..layers import TableLayer, guess_lon_lat_columns, csv_table_win_newline
 
 
 class TestLayers:
@@ -211,6 +211,14 @@ class TestLayers:
         assert layer.lon_unit is u.deg
         assert layer.lat_att == 'b'
         assert layer.alt_att == ''
+
+    def test_line_endings(self):
+        self.table['ra'] = [1,2,3]
+        expected_str = "flux,dec,ra\r\n"\
+                        "2,4,1\r\n"\
+                        "3,5,2\r\n"\
+                        "4,6,3\r\n"
+        assert csv_table_win_newline(self.table) == expected_str
 
     def test_deprecated_api_call(self, capsys):
         """For the time being, test that the deprecated name for this function still


### PR DESCRIPTION
Windows would not display table layers due to the way we were previously normalizing line endings for WWT. This PR fixes that problem.