### PR TITLE
Add FITS MIME type

### DIFF
--- a/pywwt/jupyter_server.py
+++ b/pywwt/jupyter_server.py
@@ -73,5 +73,7 @@ def load_jupyter_server_extension(nb_server_app):
         with open(CONFIG, 'w') as f:
             json.dump(config, f)
 
+    mimetypes.add_type('image/fits','.fits')
+
     route_pattern = url_path_join(web_app.settings['base_url'], '/wwt/(.*)')
     web_app.add_handlers(host_pattern, [(route_pattern, WWTFileHandler)])

--- a/pywwt/jupyter_server.py
+++ b/pywwt/jupyter_server.py
@@ -74,6 +74,8 @@ def load_jupyter_server_extension(nb_server_app):
             json.dump(config, f)
 
     mimetypes.add_type('image/fits','.fits')
+    mimetypes.add_type('image/fits','.fts')
+    mimetypes.add_type('image/fits','.fit')
 
     route_pattern = url_path_join(web_app.settings['base_url'], '/wwt/(.*)')
     web_app.add_handlers(host_pattern, [(route_pattern, WWTFileHandler)])


### PR DESCRIPTION
The python mimetype library does not include the MIME type information for FITS files by default, so we have to add it. Otherwise adding FITS images breaks pywwt on notebooks 5.7.6 and up. (See #191 and #192 for more info on notebooks and MIME types)