### PR TITLE
docs: fix link-checking

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -201,3 +201,22 @@ nitpick_ignore = [('py:class', 'ipywidgets.widgets.domwidget.DOMWidget')]
 default_role = 'obj'
 
 html_logo = 'images/logo.png'
+
+
+# When checking links, the webserver for GitBook.io can currently return more
+# than 100 HTTP headers sometimes ("Link:" headers giving hints about
+# fragmented JavaScript files to load), which Python's HTTP libraries reject
+# by default. Here's a hack to make the problem go away. Credit:
+# https://stackoverflow.com/a/38815673/3760486 .
+
+try:
+    import http.client  # Python 3
+    http.client._MAXHEADERS = 1000
+except ImportError:
+    pass
+
+try:
+    import httplib  # Python 2
+    httplib._MAXHEADERS = 1000
+except ImportError:
+    pass

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -62,8 +62,8 @@ if using pip). For the record, these dependencies are as follows:
 * `Python <https://www.python.org>`_ 2.7, or 3.5 or later
 * `NumPy <https://www.numpy.org>`_ 1.9 or later
 * `Matplotlib <https://matplotlib.org>`_ 1.5 or later
-* `Astropy <http://www.astropy.org>`_ 1.0 or later
-* `Requests <http://docs.python-requests.org/en/latest/>`_
+* `Astropy <https://www.astropy.org>`_ 1.0 or later
+* `Requests <https://2.python-requests.org/en/latest/>`_
 * `Beautiful Soup 4 <https://www.crummy.com/software/BeautifulSoup>`_
 * `Dateutil <http://labix.org/python-dateutil>`_
 * `lxml <https://lxml.de>`_


### PR DESCRIPTION
Including a fun problem that the server for GitBook.io returns more than 100 HTTP headers, which Python doesn't like.