### PR TITLE
Fix separate-pane resizing in recent JupyterLab

### DIFF
--- a/lib/wwt.js
+++ b/lib/wwt.js
@@ -75,47 +75,54 @@ var WWTView = widgets.DOMWidgetView.extend({
 
     relayout: function() {
         // Only do resizing if we are not in the notebook context but in a
-        // split panel context. We find this out by checking that the fourth
-        // parent of the current element has the jp-MainAreaWidget class.
-        parent = this.el.parentNode.parentNode.parentNode.parentNode;
+        // split panel context. We find this out by checking if one of the
+        // parents of the current element has the jp-MainAreaWidget class --
+        // either the fourth or the third, depending on which version of
+        // JupyterLab is being used.
+        parent = this.el.parentNode.parentNode.parentNode;
 
-        if (parent.classList.contains("jp-MainAreaWidget")) {
-            // Note that the approach below assumes that the WWT widget is the
-            // only output in the split panel, but if not, then we might end
-            // up with a size that is too large, so this should be fixed in
-            // future.
-            //
-            // We now check whether the iframe is actually present inside this
-            // element.
-            iframe = this.el.getElementsByTagName('iframe')[0];
+        if (!parent.classList.contains("jp-MainAreaWidget")) {
+            parent = parent.parentNode;
 
-            if (iframe != null) {
-                // The height of the widget element defaults to 400 pixels,
-                // but here we change it to simply be 100% of the available
-                // vertical space. However, we also need to do this for the
-                // element two levels up otherwise it defaults to a tighter
-                // layout. Note that this is essentially a hack since there is
-                // no guarantee the DOM will remain constant in future inside
-                // Jupyter, so this should be fixed at the Jupyter level
-                // ideally.
-                this.el.style.setProperty('height', '100%', '');
-                this.el.parentNode.parentNode.style.setProperty('height', '100%')
-
-                // Once we do this, the current element will expand to the
-                // full size of the panel. We then use offsetWidth and
-                // offsetHeight to get the real size of the current element.
-                width = this.el.offsetWidth;
-                height = this.el.offsetHeight;
-
-                // Finally we set the size of the iframe - however we subtract
-                // a little to account for the fact that there is a margin in
-                // the Jupyter panel. Again this is not ideal to have
-                // hard-coded so we need to find a better solution in the long
-                // term.
-                iframe.width = width - 10;
-                iframe.height = height - 10;
+            if (!parent.classList.contains("jp-MainAreaWidget")) {
+                // OK, neither has the class; looks like we're not in the Lab.
+                // Nothing to do here.
+                return;
             }
         }
+
+        // Note that the approach below assumes that the WWT widget is the
+        // only output in the split panel, but if not, then we might end up
+        // with a size that is too large, so this should be fixed in future.
+        //
+        // We now check whether the iframe is actually present inside this
+        // element. If not, there's no view to monkey with.
+        iframe = this.el.getElementsByTagName('iframe')[0];
+        if (iframe == null)
+            return;
+
+        // The height of the widget element defaults to 400 pixels, but here
+        // we change it to simply be 100% of the available vertical space.
+        // However, we also need to do this for the element two levels up
+        // otherwise it defaults to a tighter layout. Note that this is
+        // essentially a hack since there is no guarantee the DOM will remain
+        // constant in future inside Jupyter, so this should be fixed at the
+        // Jupyter level ideally.
+        this.el.style.setProperty('height', '100%', '');
+        this.el.parentNode.parentNode.style.setProperty('height', '100%');
+
+        // Once we do this, the current element will expand to the full size
+        // of the panel. We then use offsetWidth and offsetHeight to get the
+        // real size of the current element.
+        width = this.el.offsetWidth;
+        height = this.el.offsetHeight;
+
+        // Finally we set the size of the iframe - however we subtract a
+        // little to account for the fact that there is a margin in the
+        // Jupyter panel. Again this is not ideal to have hard-coded so we
+        // need to find a better solution in the long term.
+        iframe.width = width - 10;
+        iframe.height = height - 10;
     },
 
     handle_custom_message: function(msg) {

--- a/lib/wwt.js
+++ b/lib/wwt.js
@@ -74,50 +74,48 @@ var WWTView = widgets.DOMWidgetView.extend({
     },
 
     relayout: function() {
+        // Only do resizing if we are not in the notebook context but in a
+        // split panel context. We find this out by checking that the fourth
+        // parent of the current element has the jp-MainAreaWidget class.
+        parent = this.el.parentNode.parentNode.parentNode.parentNode;
 
-      // Only do resizing if we are not in the notebook context but in a split
-      // panel context. We find this out by checking that the fourth parent
-      // of the current element has the jp-MainAreaWidget class.
-      parent = this.el.parentNode.parentNode.parentNode.parentNode
+        if (parent.classList.contains("jp-MainAreaWidget")) {
+            // Note that the approach below assumes that the WWT widget is the
+            // only output in the split panel, but if not, then we might end
+            // up with a size that is too large, so this should be fixed in
+            // future.
+            //
+            // We now check whether the iframe is actually present inside this
+            // element.
+            iframe = this.el.getElementsByTagName('iframe')[0];
 
-      if (parent.classList.contains("jp-MainAreaWidget")) {
+            if (iframe != null) {
+                // The height of the widget element defaults to 400 pixels,
+                // but here we change it to simply be 100% of the available
+                // vertical space. However, we also need to do this for the
+                // element two levels up otherwise it defaults to a tighter
+                // layout. Note that this is essentially a hack since there is
+                // no guarantee the DOM will remain constant in future inside
+                // Jupyter, so this should be fixed at the Jupyter level
+                // ideally.
+                this.el.style.setProperty('height', '100%', '');
+                this.el.parentNode.parentNode.style.setProperty('height', '100%')
 
-        // Note that the approach below assumes that the WWT widget is the only
-        // output in the split panel, but if not, then we might end up with a
-        // size that is too large, so this should be fixed in future.
+                // Once we do this, the current element will expand to the
+                // full size of the panel. We then use offsetWidth and
+                // offsetHeight to get the real size of the current element.
+                width = this.el.offsetWidth;
+                height = this.el.offsetHeight;
 
-        // We now check whether the iframe is actually present inside this element
-        iframe = this.el.getElementsByTagName('iframe')[0];
-
-        if (iframe != null) {
-
-          // The height of the widget element defaults to 400 pixels, but here
-          // we change it to simply be 100% of the available vertical space.
-          // However, we also need to do this for the element two levels up
-          // otherwise it defaults to a tighter layout. Note that this is
-          // essentially a hack since there is no guarantee the DOM will remain
-          // constant in future inside Jupyter, so this should be fixed at the
-          // Jupyter level ideally.
-          this.el.style.setProperty('height', '100%', '');
-          this.el.parentNode.parentNode.style.setProperty('height', '100%')
-
-          // Once we do this, the current element will expand to the full size
-          // of the panel. We then use offsetWidth and offsetHeight to get the
-          // real size of the current element.
-          width = this.el.offsetWidth;
-          height = this.el.offsetHeight;
-
-          // Finally we set the size of the iframe - however we subtract a
-          // little to account for the fact that there is a margin in the
-          // Jupyter panel. Again this is not ideal to have hard-coded so we
-          // need to find a better solution in the long term.
-          iframe.width = width - 10;
-          iframe.height = height - 10;
-
+                // Finally we set the size of the iframe - however we subtract
+                // a little to account for the fact that there is a margin in
+                // the Jupyter panel. Again this is not ideal to have
+                // hard-coded so we need to find a better solution in the long
+                // term.
+                iframe.width = width - 10;
+                iframe.height = height - 10;
+            }
         }
-
-      }
-
     },
 
     handle_custom_message: function(msg) {


### PR DESCRIPTION
I need this in version 0.35.6.

(The diff looks gnarly but it's mostly indentation; there's some control flow rearrangement, but the action is basically in the revised first stanza.)