### PR TITLE
Work on image-display user experience

### DIFF
--- a/lib/wwt.js
+++ b/lib/wwt.js
@@ -135,10 +135,30 @@ var WWTView = widgets.DOMWidgetView.extend({
         msg['url'] = this.wwt_base_url + msg['url'];
       }
 
-      this.wwt_window.wwt_apply_json_message(this.wwt_window.wwt, msg);
+      // If the user has created a view for our widget and then hidden it, our
+      // iframe gets removed and all sorts of things stop working (e.g.,
+      // Chrome will refuse to send XMLHttpRequests anymore, and Firefox won't
+      // set timeouts). If we let exceptions from these operations bubble up,
+      // they break the code that applies widget events to *all* views, which
+      // then breaks the JupyterLab use case of (1) setting up a WWT widget,
+      // (2) creating a view of it in a separate tab, and then (3) hiding the
+      // view in the original notebook, because the second view will never
+      // receive any messages. We should handle things better when widgets get
+      // hidden, but in the meantime, try to keep things limping along by
+      // swallowing exceptions here. Note that this approach will mean that
+      // the two views will get out of sync regarding, e.g., image layers that
+      // have been loaded.
 
-      if (msg['event'] === 'center_on_coordinates') {
+      try {
+        this.wwt_window.wwt_apply_json_message(this.wwt_window.wwt, msg);
+
+        if (msg['event'] === 'center_on_coordinates') {
           this.update_view_data();
+        }
+      } catch (e) {
+        console.log('failed to process custom_message for a pyWWT Jupyter widget view:');
+        console.log(msg);
+        (console.error || console.log).call(console, e.stack || e);
       }
     },
 

--- a/pywwt/core.py
+++ b/pywwt/core.py
@@ -72,10 +72,20 @@ class BaseWWTWidget(HasTraits):
     def _send_msg(self, **kwargs):
         # This method should be overridden and should send the message to WWT
         pass
-    
+
     def _get_view_data(self, field):
         # This method should be overwritten to get the RA, Dec, and FoV of the current view
         pass
+
+    def _create_image_layer(self, **kwargs):
+        """This method can be overridden to return specialized subclasses of
+        :class:`~pywwt.layers.ImageLayer`. In particular, the Jupyter version
+        of the viewer extends ``ImageLayer`` to add methods that add
+        interactive UI controls for the layer parameters.
+
+        """
+        from .layers import ImageLayer
+        return ImageLayer(self, **kwargs)
 
     actual_planet_scale = Bool(False,
                                help='Whether to show planets to scale or as '

--- a/pywwt/layers.py
+++ b/pywwt/layers.py
@@ -595,28 +595,28 @@ class ImageLayer(HasTraits):
 
         self._image_url = self.parent._serve_file(self._sanitized_image, extension='.fits')
 
-        # Because of the way the image loading works in WWT, we may end up with
-        # messages being applied out of order (see notes in image_layer_stretch
-        # in wwt_json_api.js)
+        # Default the image rendering parameters. Because of the way the image
+        # loading works in WWT, we may end up with messages being applied out
+        # of order (see notes in image_layer_stretch in wwt_json_api.js)
         self._stretch_version = 0
 
+        data = fits.getdata(self._sanitized_image)
+        self.vmin = np.nanpercentile(data, 0.5)
+        self.vmax = np.nanpercentile(data, 99.5)
+
         self._initialize_layer()
-
-        # Force defaults
-        self._on_trait_change({'name': 'opacity', 'new': self.opacity})
-
-        self.observe(self._on_trait_change, type='change')
 
         if any(key not in self.trait_names() for key in kwargs):
             raise KeyError('a key doesn\'t match any layer trait name')
 
         super(ImageLayer, self).__init__(**kwargs)
 
-        # Determine initial stretch parameters
-        data = fits.getdata(self._sanitized_image)
+        # Apply settings (that the user may have overridden) and track changes
+        # automagically going forward.
+        self._on_trait_change({'name': 'vmin', 'new': self.vmin})
+        self._on_trait_change({'name': 'opacity', 'new': self.opacity})
+        self.observe(self._on_trait_change, type='change')
 
-        self.vmin = np.nanpercentile(data, 0.5)
-        self.vmax = np.nanpercentile(data, 99.5)
 
     @validate('stretch')
     def _check_stretch(self, proposal):

--- a/pywwt/layers.py
+++ b/pywwt/layers.py
@@ -601,8 +601,8 @@ class ImageLayer(HasTraits):
         self._stretch_version = 0
 
         data = fits.getdata(self._sanitized_image)
-        self.vmin = np.nanpercentile(data, 0.5)
-        self.vmax = np.nanpercentile(data, 99.5)
+        self._data_min, self.vmin, self.vmax, self._data_max = \
+            np.nanpercentile(data, [0, 0.5, 99.5, 100])
 
         self._initialize_layer()
 

--- a/pywwt/layers.py
+++ b/pywwt/layers.py
@@ -132,9 +132,9 @@ class LayerManager(object):
 
         Returns
         -------
-        layer : :class:`~pywwt.layers.ImageLayer`
+        layer : :class:`~pywwt.layers.ImageLayer` or a subclass thereof
         """
-        layer = ImageLayer(self._parent, image=image, **kwargs)
+        layer = self._parent._create_image_layer(image=image, **kwargs)
         self._add_layer(layer)
         return layer
 


### PR DESCRIPTION
(This PR is cumulative on #216)

The main goal here is to add controls to the Jupyter widget so that the user can interactively tune the image stretch parameters straight in their notebook.

![Screenshot from 2019-06-05 14-34-46](https://user-images.githubusercontent.com/59598/58980832-26ae0780-879f-11e9-8aff-a47bec5b5338.png)

I set this up so that the Qt version of the widget should be unaffected.

I also ran into some issues with hidden JupyterLab widget views that look pretty thorny; I have some lengthy commit messages describing what I found and a workaround I put into place.