### PR TITLE
Include all available imagery layers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,11 @@
 
 - No changes yet.
 
+0.6.2 (unreleased)
+------------------
+
+- Expose all available imagery layers. [#220]
+
 0.6.1 (2019-06-10)
 ------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -220,3 +220,6 @@ try:
     httplib._MAXHEADERS = 1000
 except ImportError:
     pass
+
+linkcheck_retries = 5
+linkcheck_timeout = 10

--- a/pywwt/imagery.py
+++ b/pywwt/imagery.py
@@ -28,9 +28,7 @@ def get_imagery_layers(url):
     e = ElementTree()
     t = e.parse(b)
 
-    # For now only look at the ImageSets at the root of the
-    # XML since these seem to be the main surveys.
-    for survey in t.findall('ImageSet'):
+    for survey in t.iter('ImageSet'):
         name = survey.attrib['Name']
         thumbnail_url = survey.find('ThumbnailUrl').text
         if not thumbnail_url:


### PR DESCRIPTION
There's no real reason to keep the initial restriction of having only top-level surveys in the available imagery layers, so this is a small fix to make sure we expose all of them:

```
In [5]: wwt.available_layers                                                                                                                           
Out[5]: 
['2MASS: Catalog (Synthetic, Near Infrared)',
 '2MASS: Two Micron All Sky Survey (Synthetic, Near Infrared)',
 '2Mass: Imagery (Infrared)',
 'Big Picture (Optical)',
 'Black Sky Background',
 'Bonn 1420 MHz Survey (Radio)',
 'CGRO Compton Telescope: 3 channel data (Gamma)',
 'COBE DIRBE (Infrared)',
 'COBE DIRBE Annual Average Map (Infrared)',
 'COBE DIRBE Zodi-Subtracted Mission Average (Infrared)',
 'Digitized Sky Survey (Color)',
 'EGRET Hard (Gamma)',
 'EGRET Soft (Gamma)',
 'EUVE 171 : Extreme Ultraviolet Explorer 171 Angstroms',
 'EUVE 405 : Extreme Ultraviolet Explorer 405 Angstroms',
 'EUVE 555 : Extreme Ultraviolet Explorer 555 Angstroms',
 'EUVE 83 : Extreme Ultraviolet Explorer 83 Angstroms',
 'Extreme Ultraviolet Explorer',
 'Fermi (Gamma)',
 'Fermi LAT 8-year (gamma)',
 'Fermi Six Months (Gamma)',
 'Fermi Year Three (Gamma)',
 'Fermi Year Two (Gamma)',
 'GALEX (Ultraviolet)',
 'GALEX 2 Combined',
 'GALEX 2 Far-UV',
 'GALEX 2 Near-UV',
 'GALEX 4 Far-UV',
 'GALEX 4 Near-UV',
 'GLIMPSE 360',
 'GLIMPSE/MIPSGAL',
 'GRANAT/SIGMA Flux (X-Ray)',
 'GRANAT/SIGMA Significance (X-Ray)',
 'HI All-Sky Continuum Survey (Radio)',
 'Hydrogen Alpha Full Sky Map',
 'IRIS 100 Microns (Infrared)',
 'IRIS 12 Microns (Infrared)',
 'IRIS 25 Microns (Infrared)',
 'IRIS 60 Microns (Infrared)',
 'IRIS: Improved Reprocessing of IRAS Survey (Infrared)',
 'NVSS: NRAO VLA Sky Survey (Radio)',
 'Planck CMB',
 'Planck Dust & Gas',
 'Planck Ionized Gas (free-free)',
 'Planck Lensing (Mass)',
 'Planck Molecular Gas (CO)',
 'Planck Spinning Dust',
 'Planck Synchrotron (non-thermal)',
 'Planck Thermal Dust',
 'RASS: ROSAT All Sky Survey (X-ray)',
 'ROSAT Broad Band Count Map (X-Ray)',
 'ROSAT Hard Band Count Map (X-Ray)',
 'ROSAT Hard Band Intensity (X-Ray)',
 'ROSAT PSPC summed pointed observations, 2 degree cutoff, intensity (X-Ray)',
 'ROSAT Soft Band Count Map (X-Ray)',
 'ROSAT Soft Band Intensity (X-Ray)',
 'SDSS: Sloan Digital Sky Survey (Optical)',
 'SFD 100 Micron (Infrared)',
 'SFD Dust Map (Infrared)',
 'SUMSS: Sydney University Molonglo Sky Survey (Radio)',
 'Swift BAT All-Sky Survey: Flux 14-195 keV (X-Ray)',
 'Swift BAT All-Sky Survey: Significance 14-195 keV (X-Ray)',
 'Tycho (Synthetic, Optical)',
 'USNOB: US Naval Observatory B 1.0 (Synthetic, Optical)',
 'VLA FIRST: Faint Images of the Radio Sky at Twenty-centimeters',
 'VLSS: VLA Low-frequency Sky Survey (Radio)',
 'WISE All Sky (Infrared)',
 'WMAP Cosmic Microwave Background',
 'WMAP ILC 5-Year CMB',
 'WMAP ILC 5-Year Cosmic Microwave Background',
 'WMAP K (Linear) 23 GHz',
 'WMAP K (Non-linear) 23 GHz',
 'WMAP K (Polarization Map) 50 uK',
 'WMAP K Band (Microwave)',
 'WMAP Ka (Linear) 33 GHz',
 'WMAP Ka (Non-linear) 33 GHz',
 'WMAP Ka (Polarization Map) 35 uK',
 'WMAP Ka Band (Microwave)',
 'WMAP Q (Linear) 41 GHz',
 'WMAP Q (Non-linear) 41 GHz',
 'WMAP Q (Polarization Map) 35 uK',
 'WMAP Q Band (Microwave)',
 'WMAP QVW Linear (Microwave)',
 'WMAP QVW Power (Microwave)',
 'WMAP V (Linear) 61 GHz',
 'WMAP V (Non-linear) 61 GHz',
 'WMAP V (Polarization Map) 35 uK',
 'WMAP V Band (Microwave)',
 'WMAP W (Linear) 94 GHz',
 'WMAP W (Non-linear) 94 GHz',
 'WMAP W (Polarization Map) 35 uK',
 'WMAP W Band (Microwave)',
 'Westerbork Northern Sky Survey (Radio)']
```

I've put this under 0.6.2 since I view this as a bug that we aren't currently exposing all the layers, and I'd forgotten we had placed that initial restriction.