### PR TITLE
Make use of fast colormapping in SDK

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,10 +5,11 @@
   cases, the performance is e.g. more than 1000x better for a 50,000 row
   dataset. [#224]
 
-- Added a ``cmap`` parameter on image layers to control the colormap. [#244]
+- Improve performance when changing colormap parameters for tabular
+  layers, for a subset of colormaps. In these cases, the performance
+  is e.g. more than 1000x better for a 50,000 row dataset. [#223]
 
-0.7.1 (unreleased)
-------------------
+- Added a ``cmap`` parameter on image layers to control the colormap. [#244]
 
 - Incorporate time series behavior for data layers; add method that
   returns current time in the viewer. [#187]

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -64,7 +64,7 @@ if using pip). For the record, these dependencies are as follows:
 * `NumPy <https://www.numpy.org>`_ 1.9 or later
 * `Matplotlib <https://matplotlib.org>`_ 1.5 or later
 * `Astropy <https://www.astropy.org>`_ 1.0 or later
-* `Requests <https://2.python-requests.org/en/latest/>`_
+* `Requests <https://requests.kennethreitz.org/en/master/>`_
 * `Beautiful Soup 4 <https://www.crummy.com/software/BeautifulSoup>`_
 * `Dateutil <http://labix.org/python-dateutil>`_
 * `lxml <https://lxml.de>`_

--- a/pywwt/nbextension/static/wwt_json_api.js
+++ b/pywwt/nbextension/static/wwt_json_api.js
@@ -314,7 +314,8 @@ function wwt_apply_json_message(wwt, msg) {
 
       // Use updateData instead of loadFromString here since updateData also
       // takes care of cache invalidation.
-      layer.upadteData(csv, true, true, true)
+      layer.updateData(csv, true, true, true)
+
       break;
 
     case 'table_layer_set':

--- a/pywwt/nbextension/static/wwt_json_api.js
+++ b/pywwt/nbextension/static/wwt_json_api.js
@@ -327,6 +327,8 @@ function wwt_apply_json_message(wwt, msg) {
         value = layer.get__table().header.indexOf(msg['value']);
       } else if(name == 'color') {
         value = wwtlib.Color.fromHex(msg['value']);
+      } else if(name == 'colorMapper') {
+        value = wwtlib.ColorMapContainer.fromNestedLists(msg['value']);
       } else if(name == 'altUnit') {
         value = wwtlib.AltUnits[msg['value']];
       } else if(name == 'raUnits') {


### PR DESCRIPTION
This PR switches the colormapping of points to use the API that is being proposed in https://github.com/WorldWideTelescope/wwt-web-client/pull/238. For colormaps that are supported by the web client (which we can easily expand the list of), we use the new efficient route, while for other colormaps, we use the old approach. The following example shows that the old approach is more than 1000x slower for a 50,000 row dataset (``RdBu`` shows the old approach):

```python
In [1]: from pywwt.qt import WWTQtClient   
   ...: %gui qt                                                                   
   ...: wwt = WWTQtClient(block_until_ready=True)   
   ...: from astropy.table import Table                                           
   ...: table = Table()                                                           
   ...: import numpy as np                                                        
   ...: table['ra'] = np.random.uniform(0, 360, 50_000)                          
   ...: table['dec'] = np.random.uniform(-90, 90, 50_000)                        
   ...: table['mass'] = np.random.uniform(0.01, 0.1, 50_000)                        
   ...: layer = wwt.layers.add_data_layer(table, cmap_att='mass')   

In [2]: layer.size_scale = 40                                                                                                                          

In [4]: %time layer.cmap = 'viridis'                                                                                                                   
CPU times: user 965 µs, sys: 174 µs, total: 1.14 ms
Wall time: 586 µs

In [5]: %time layer.cmap = 'RdBu'                                                                                                                      
CPU times: user 2.42 s, sys: 115 ms, total: 2.54 s
Wall time: 2.08 s

In [6]: %time layer.cmap_vmax = 0.12                                                                                                                   
CPU times: user 2.4 s, sys: 133 ms, total: 2.54 s
Wall time: 2.12 s

In [7]: %time layer.cmap = 'inferno'                                                                                                                   
CPU times: user 372 µs, sys: 79 µs, total: 451 µs
Wall time: 312 µs

In [8]: %time layer.cmap_vmax = 0.15                                                                                                                   
CPU times: user 1.63 ms, sys: 836 µs, total: 2.46 ms
Wall time: 1.05 ms
```

This will need to wait for the ``wwtsdk.js`` file to be updated in the gh-pages branch before being merged.