### PR TITLE
Make use of fast size scaling in SDK

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,11 @@
-0.7.1
+0.8.0 (unreleased)
+------------------
+
+- Improve performance when changing size parameters for tabular layers. In these
+  cases, the performance is e.g. more than 1000x better for a 50,000 row
+  dataset. [#224]
+
+0.7.1 (unreleased)
 ------------------
 
 - Incorporate time series behavior for data layers; add method that

--- a/pywwt/layers.py
+++ b/pywwt/layers.py
@@ -621,24 +621,26 @@ class TableLayer(HasTraits):
         # Update the size column in the table
 
         if self._uniform_size():
+
             self.parent._send_msg(event='table_layer_set', id=self.id,
                                   setting='sizeColumn', value=-1)
-            return
 
-        column = self.table[self.size_att]
+        else:
 
-        size = (column - self.size_vmin) / (self.size_vmax - self.size_vmin) * 10
+            self.parent._send_msg(event='table_layer_set', id=self.id,
+                                  setting='pointScaleType', value=0)
 
-        self.table[SIZE_COLUMN_NAME] = size
+            self.parent._send_msg(event='table_layer_set', id=self.id,
+                                  setting='sizeColumn', value=SIZE_COLUMN_NAME)
 
-        self.parent._send_msg(event='table_layer_update', id=self.id,
-                              table=self._table_b64)
+            self.parent._send_msg(event='table_layer_set', id=self.id,
+                                  setting='normalizeSize', value=True)
 
-        self.parent._send_msg(event='table_layer_set', id=self.id,
-                              setting='pointScaleType', value=0)
+            self.parent._send_msg(event='table_layer_set', id=self.id,
+                                  setting='normalizeSizeMin', value=self.size_vmin)
 
-        self.parent._send_msg(event='table_layer_set', id=self.id,
-                              setting='sizeColumn', value=SIZE_COLUMN_NAME)
+            self.parent._send_msg(event='table_layer_set', id=self.id,
+                                  setting='normalizeSizeMax', value=self.size_vmax)
 
     @observe('cmap_att')
     def _on_cmap_att_change(self, *value):

--- a/pywwt/layers.py
+++ b/pywwt/layers.py
@@ -631,7 +631,7 @@ class TableLayer(HasTraits):
                                   setting='pointScaleType', value=0)
 
             self.parent._send_msg(event='table_layer_set', id=self.id,
-                                  setting='sizeColumn', value=SIZE_COLUMN_NAME)
+                                  setting='sizeColumn', value=self.size_att)
 
             self.parent._send_msg(event='table_layer_set', id=self.id,
                                   setting='normalizeSize', value=True)

--- a/pywwt/layers.py
+++ b/pywwt/layers.py
@@ -637,6 +637,9 @@ class TableLayer(HasTraits):
                                   setting='normalizeSize', value=True)
 
             self.parent._send_msg(event='table_layer_set', id=self.id,
+                                  setting='normalizeSizeClip', value=True)
+
+            self.parent._send_msg(event='table_layer_set', id=self.id,
                                   setting='normalizeSizeMin', value=self.size_vmin)
 
             self.parent._send_msg(event='table_layer_set', id=self.id,


### PR DESCRIPTION
This is a companion to https://github.com/WorldWideTelescope/pywwt/pull/223 that makes use of the improvements in the web client SDK in https://github.com/WorldWideTelescope/wwt-web-client/pull/237 to allow efficient size scaling of points by attributes.

This results in performance enhancements when changing e.g. the min/max for the size scaling on the Python side since we no longer keep sending the full data from Python to JS. Consider the following example with the original code before this PR:

```python
In [1]: from pywwt.qt import WWTQtClient  
   ...: %gui qt                                                                  
   ...: wwt = WWTQtClient(block_until_ready=True)  
   ...: from astropy.table import Table                                          
   ...: table = Table()                                                          
   ...: import numpy as np                                                       
   ...: table['ra'] = np.random.uniform(0, 360, 50_000)                         
   ...: table['dec'] = np.random.uniform(-90, 90, 50_000)                       
   ...: table['mass'] = np.random.uniform(0.01, 0.1, 50_000)                       
   ...: layer = wwt.layers.add_data_layer(table, size_att='mass', size_scale=1) 

In [2]: %time layer.size_vmax = 0.12                                                                                                                   
CPU times: user 770 ms, sys: 93.5 ms, total: 864 ms
Wall time: 752 ms

In [3]: %time layer.size_vmin = 0.                                                                                                                     
CPU times: user 710 ms, sys: 86.1 ms, total: 796 ms
Wall time: 691 ms
```

With this PR, these operations are significantly faster, on the order of 2000x times in this particular case:

```python
In [1]: from pywwt.qt import WWTQtClient  
   ...: %gui qt                                                                  
   ...: wwt = WWTQtClient(block_until_ready=True)  
   ...: from astropy.table import Table                                          
   ...: table = Table()                                                          
   ...: import numpy as np                                                       
   ...: table['ra'] = np.random.uniform(0, 360, 50_000)                         
   ...: table['dec'] = np.random.uniform(-90, 90, 50_000)                       
   ...: table['mass'] = np.random.uniform(0.01, 0.1, 50_000)                       
   ...: layer = wwt.layers.add_data_layer(table, size_att='mass') 

In [2]: %time layer.size_vmax = 0.12                                                                                                                   
CPU times: user 233 µs, sys: 38 µs, total: 271 µs
Wall time: 195 µs

In [3]: %time layer.size_vmin = 0.                                                                                                                     
CPU times: user 294 µs, sys: 42 µs, total: 336 µs
Wall time: 237 µs
```

Note that this PR also changes the sizes to no longer be multiplied by 10 on top of the ``size_scale``, hence why the first example has ``size_scale`` set (so that the actual output matches).
