### PR TITLE
RELEASE.rst: tweak the release notes

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,16 +1,23 @@
 Releasing
 =========
 
-To do a release, first edit the ``CHANGES.rst`` file to include the date of the
-release after the version number, and make sure the changelog is up to date.
+Start the release process by creating a new branch named
+``release-<version>``, where ``<version>`` will be the version to be released.
 
-Then edit the following files to update the version numbers:
+The first real step is edit the ``CHANGES.rst`` file to include the date of
+the release after the version number. Make sure the changelog is up to
+date, using::
+
+    git log v<prev>..HEAD
+
+to review the commit history. Then edit the following files to update the
+version numbers:
 
 * ``docs/conf.py``
 * ``pywwt/_version.py`` (make sure the string in the tuple is set to ``final``)
+* ``pywwt/jupyter.py``
 * ``lib/wwt.js``
 * ``package.json``
-* ``pywwt/jupyter.py``
 
 At this point, commit all changes and use the following for the commit message::
 
@@ -25,9 +32,18 @@ and build the release files::
     python setup.py sdist bdist_wheel --universal
 
 Go inside the ``dist`` directory, and you should see a tar file and a wheel.
-At this point, if you wish, you can untar the tar file and try installing and
-testing the installation. Once you are satisfied that the release is good
-you can upload the release using twine::
+At this point, you should try::
+
+    pip install dist/pywwt-*.tar.gz
+
+and validate the package as extensively as you can.
+
+Push the current branch to GitHub and create a pull request against
+``master``. Get final validation that the CI likes the release commit, but do
+*not* merge the PR yet.
+
+Once you are satisfied that the release is good you can upload the release
+using twine::
 
     twine upload pywwt-*.tar.gz pywwt-*-none-any.whl
 
@@ -50,8 +66,29 @@ releases as well::
 
     git branch v0.N.x
 
-Now change the versions in the files listed above to the next version - and for
-the ``pywwt/_version.py`` file, change ``final`` to ``dev``. Commit the changes
-with::
+Now change the versions in the files listed above to the next version. For the
+``pywwt/_version.py`` file, change ``final`` to ``dev``. Commit the changes
+with the message::
 
     Back to development: v<next_version>
+
+Push this update to your release PR branch and let the CI run again.
+
+While waiting, update the ``stable`` branch to trigger an update on
+ReadTheDocs::
+
+    git push wwt v<version>:stable
+
+Here, ``wwt`` is the name of the Git remote corresponding to
+``WorldWideTelescope/pywwit.git`` on GitHub. A ``-f`` flag may be necessary if
+the previous release had backports cherry-picked from ``master``.
+
+When the CI on your release branch has finished, merge it into ``master``.
+Push your release tag::
+
+    git push --tags
+
+If necessary, also push your ``v0.N.x`` point-release branch.
+
+Finally, create a new release on GitHub. Copy the release notes from
+``CHANGES.rst``, adapting the ReStructuredText markup to Markdown.


### PR DESCRIPTION
Mention updating the `stable` branch to update the ReadTheDocs docs. Also mention creating a new release on GitHub.

Finally, recommend a workflow in which the release commits are submitted via a pull request, so that that there is a CI run on the release candidate commit and the HEAD commit that keeps master at a development version.