### PR TITLE
Allow layer names to be specified, and default to UUID

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,13 +1,11 @@
 0.9.0 (unreleased)
 ------------------
 
-- No changes yet.
+- Added a ``name`` attribute for table and image layers, and set layer names
+  to unique IDs if not specified. [#235]
 
 0.8.0 (2020-04-03)
 ------------------
-
-- Added a ``name`` attribute for table and image layers, and set layer names
-  to unique IDs if not specified. [#235]
 
 - Improve performance when changing size parameters for tabular layers. In these
   cases, the performance is e.g. more than 1000x better for a 50,000 row

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@
 0.8.0 (2020-04-03)
 ------------------
 
+- Added a ``name`` attribute for table and image layers, and set layer names
+  to unique IDs if not specified. [#235]
+
 - Improve performance when changing size parameters for tabular layers. In these
   cases, the performance is e.g. more than 1000x better for a 50,000 row
   dataset. [#224]

--- a/pywwt/layers.py
+++ b/pywwt/layers.py
@@ -308,6 +308,8 @@ class TableLayer(HasTraits):
     A layer where the data is stored in an :class:`~astropy.table.Table`
     """
 
+    name = Unicode(help='The name of the layer', allow_none=True)
+
     coord_type = Unicode('spherical', help='Whether to give the coordinates '
                          'in spherical or rectangular coordinates').tag(wwt='coordinatesType')
 
@@ -790,8 +792,9 @@ class TableLayer(HasTraits):
         return not self.size_att or self.size_vmin is None or self.size_vmax is None
 
     def _initialize_layer(self):
-        self.parent._send_msg(event='table_layer_create',
-                              id=self.id, table=self._table_b64, frame=self.frame)
+        self.parent._send_msg(event='table_layer_create', id=self.id,
+                              name=self.name or self.id,
+                              table=self._table_b64, frame=self.frame)
 
     def update_data(self, table=None):
         """
@@ -852,6 +855,7 @@ class TableLayer(HasTraits):
     def _serialize_state(self):
         state = {'id': self.id,
                  'layer_type': 'table',
+                 'name': self.name,
                  'frame': self.frame,
                  'settings': {}}
 
@@ -897,6 +901,8 @@ class ImageLayer(HasTraits):
     """
     An image layer.
     """
+
+    name = Unicode(help='The name of the layer', allow_none=True)
 
     vmin = Float(None, allow_none=True)
     vmax = Float(None, allow_none=True)
@@ -976,8 +982,8 @@ class ImageLayer(HasTraits):
             return proposal['value']
 
     def _initialize_layer(self):
-        self.parent._send_msg(event='image_layer_create',
-                              id=self.id, url=self._image_url)
+        self.parent._send_msg(event='image_layer_create', id=self.id,
+                              name=self.name or self.id, url=self._image_url)
 
     def remove(self):
         """
@@ -1025,6 +1031,7 @@ class ImageLayer(HasTraits):
     def _serialize_state(self):
         state = {'id': self.id,
                  'layer_type': 'image',
+                 'name': self.name,
                  'settings': {}
                  }
 

--- a/pywwt/layers.py
+++ b/pywwt/layers.py
@@ -308,7 +308,7 @@ class TableLayer(HasTraits):
     A layer where the data is stored in an :class:`~astropy.table.Table`
     """
 
-    name = Unicode(help='The name of the layer', allow_none=True)
+    name = Unicode(None, help='The name of the layer', allow_none=True)
 
     coord_type = Unicode('spherical', help='Whether to give the coordinates '
                          'in spherical or rectangular coordinates').tag(wwt='coordinatesType')
@@ -902,7 +902,7 @@ class ImageLayer(HasTraits):
     An image layer.
     """
 
-    name = Unicode(help='The name of the layer', allow_none=True)
+    name = Unicode(None, help='The name of the layer', allow_none=True)
 
     vmin = Float(None, allow_none=True)
     vmax = Float(None, allow_none=True)

--- a/pywwt/nbextension/static/interactive_figure/interactive_figure.js
+++ b/pywwt/nbextension/static/interactive_figure/interactive_figure.js
@@ -194,6 +194,7 @@ function loadTableLayer(layerInfo) {
     var onCsvLoad = function (data) {
         wwt_apply_json_message(wwt, {
             event: 'table_layer_create',
+            name: layerInfo['name'],
             frame: layerInfo['frame'],
             id: id,
             table: btoa(data)

--- a/pywwt/nbextension/static/wwt_json_api.js
+++ b/pywwt/nbextension/static/wwt_json_api.js
@@ -191,7 +191,7 @@ function wwt_apply_json_message(wwt, msg) {
 
     case 'image_layer_create':
 
-      layer = wwt.loadFitsLayer(msg['url']), msg['name'], true, null);
+      layer = wwt.loadFitsLayer(msg['url'], msg['name'], true, null);
       layer._stretch_version = 0;
       layer._cmap_version = 0;
 

--- a/pywwt/nbextension/static/wwt_json_api.js
+++ b/pywwt/nbextension/static/wwt_json_api.js
@@ -191,7 +191,7 @@ function wwt_apply_json_message(wwt, msg) {
 
     case 'image_layer_create':
 
-      layer = wwt.loadFits(msg['url']);
+      layer = wwt.loadFitsLayer(msg['url']), msg['name'], true, null);
       layer._stretch_version = 0;
       layer._cmap_version = 0;
 
@@ -270,7 +270,7 @@ function wwt_apply_json_message(wwt, msg) {
       // Get reference frame
       frame = msg['frame']
 
-      layer = wwtlib.LayerManager.createSpreadsheetLayer(frame, 'PyWWT Layer', csv);
+      layer = wwtlib.LayerManager.createSpreadsheetLayer(frame, msg['name'], csv);
       layer.set_referenceFrame(frame);
 
       // Override any guesses


### PR DESCRIPTION
Previously the layer names were hard-coded and not unique - but the names become important when e.g. exporting the layers to XML or to the serialized figure, so this provides a way to set the layer names (and defaults to the layer UUID if the name is not set).