### PR TITLE
Adjust imagery naming in Jupyter

### DIFF
--- a/pywwt/imagery.py
+++ b/pywwt/imagery.py
@@ -103,10 +103,10 @@ class ImageryLayers():
         while short in diction[bandpass]:
             if suffix:
                 suffix += 1
+                short = short[:-1] + str(suffix)
             else:
                 suffix = 1
-
-            short += str(suffix)
+                short += str(suffix)
 
         diction[bandpass][short] = {}
         diction[bandpass][short]['full_name'] = full_layer


### PR DESCRIPTION
This is a small adjustment to the foreground and background imagery layer naming scheme that helps names appear correctly in Jupyter. The intended behavior was that layers with the same shortened name (e.g. our 5 Fermi layers) would have object names in `wwt.imagery` like `fermi`, `fermi1`, `fermi2`, `fermi3`, etc.

This was the case in Qt, but in Jupyter they appeared as `fermi`, `fermi1`, `fermi12`, `fermi123`, etc. This PR fixes that error for me.