### PR TITLE
Allow image colormap to be set

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@
   cases, the performance is e.g. more than 1000x better for a 50,000 row
   dataset. [#224]
 
+- Added a ``cmap`` parameter on image layers to control the colormap. [#244]
+
 0.7.1 (unreleased)
 ------------------
 

--- a/pywwt/jupyter.py
+++ b/pywwt/jupyter.py
@@ -107,7 +107,7 @@ class JupyterImageLayer(ImageLayer):
 
     @property
     def controls(self):
-        from .layers import VALID_STRETCHES, VALID_COLORMAPS
+        from .layers import VALID_STRETCHES, VALID_COLORMAPS, UI_COLORMAPS
 
         if self._controls is not None:
             return self._controls
@@ -131,14 +131,16 @@ class JupyterImageLayer(ImageLayer):
         )
         link((self, 'stretch'), (stretch, 'value'))
 
+        # NB, this will crash if `self.cmap` is not one of our allowed values
+        reverse_ui_colormaps = dict((kv[1], kv[0]) for kv in UI_COLORMAPS.items())
         colormap = widgets.Dropdown(
             description='Colormap:',
-            options=VALID_COLORMAPS,
-            value=self.cmap.name,
+            options=UI_COLORMAPS.keys(),
+            value=reverse_ui_colormaps[self.cmap.name],
             layout={'width': '200px'}
         )
-        directional_link((colormap, 'label'), (self, 'cmap'))
-        directional_link((self, 'cmap'), (colormap, 'label'), lambda x: x.name)
+        directional_link((colormap, 'label'), (self, 'cmap'), lambda x: UI_COLORMAPS[x])
+        directional_link((self, 'cmap'), (colormap, 'label'), lambda x: reverse_ui_colormaps[x.name])
 
         vrange = widgets.FloatRangeSlider(
             description='Fine min/max:',

--- a/pywwt/layers.py
+++ b/pywwt/layers.py
@@ -13,6 +13,7 @@ else:
 
 import warnings
 from base64 import b64encode
+from collections import OrderedDict
 
 import numpy as np
 from astropy.io import fits
@@ -58,8 +59,25 @@ VALID_MARKER_SCALES = ['screen', 'world']
 VALID_STRETCHES = ['linear', 'log', 'power', 'sqrt', 'histeq']
 
 VALID_COLORMAPS = ['viridis', 'plasma', 'inferno', 'magma', 'cividis',
-                   'Greys', 'Purples', 'Blues', 'Greens', 'Oranges', 'Reds',
+                   'Greys', 'gray', 'Purples', 'Blues', 'Greens', 'Oranges', 'Reds',
                    'RdYlBu']
+
+UI_COLORMAPS = OrderedDict([
+    ('Viridis', 'viridis'),
+    ('Plasma', 'plasma'),
+    ('Black to white', 'gray'),
+    ('White to black', 'Greys'),
+    ('Inferno', 'inferno'),
+    ('Magma', 'magma'),
+    ('Cividis', 'cividis'),
+    ('Red-Yellow-Blue', 'RdYlBu'),
+    ('Purples', 'Purples'),
+    ('Blues', 'Blues'),
+    ('Greens', 'Greens'),
+    ('Oranges', 'Oranges'),
+    ('Reds', 'Reds'),
+])
+
 
 # Save string types for validating ISOT strings in time series tables
 if sys.version_info[0] == 2:

--- a/pywwt/layers.py
+++ b/pywwt/layers.py
@@ -20,9 +20,10 @@ from matplotlib.pyplot import cm
 from matplotlib.colors import Colormap
 from astropy import units as u
 from astropy.table import Column
-from astropy.time import Time, TimeDelta
+from astropy.time import Time
 from datetime import datetime
 
+from ipywidgets import HBox, Dropdown, FloatText, FloatSlider, link
 from traitlets import HasTraits, validate, observe
 from .traits import Color, Bool, Float, Unicode, AstropyQuantity, Any, to_hex
 from .utils import sanitize_image, validate_traits, ensure_utc
@@ -57,8 +58,8 @@ VALID_MARKER_SCALES = ['screen', 'world']
 VALID_STRETCHES = ['linear', 'log', 'power', 'sqrt', 'histeq']
 
 VALID_COLORMAPS = ['viridis', 'plasma', 'inferno', 'magma', 'cividis',
-                   'greys', 'purples', 'blues', 'greens', 'oranges', 'reds',
-                   'rdylbu']
+                   'Greys', 'Purples', 'Blues', 'Greens', 'Oranges', 'Reds',
+                   'RdYlBu']
 
 # Save string types for validating ISOT strings in time series tables
 if sys.version_info[0] == 2:
@@ -861,7 +862,7 @@ class ImageLayer(HasTraits):
     vmax = Float(None, allow_none=True)
     stretch = Unicode('linear')
     opacity = Float(1, help='The opacity of the image').tag(wwt='opacity')
-    cmap = Any(cm.Greys, help='The Matplotlib colormap '
+    cmap = Any(cm.viridis, help='The Matplotlib colormap '
                '(:class:`matplotlib.colors.ListedColormap`)').tag(wwt=None)
 
     def __init__(self, parent=None, image=None, **kwargs):
@@ -893,6 +894,7 @@ class ImageLayer(HasTraits):
         # loading works in WWT, we may end up with messages being applied out
         # of order (see notes in image_layer_stretch in wwt_json_api.js)
         self._stretch_version = 0
+        self._cmap_version = 0
 
         data = fits.getdata(self._sanitized_image)
         self._data_min, self.vmin, self.vmax, self._data_max = \
@@ -909,7 +911,7 @@ class ImageLayer(HasTraits):
         # automagically going forward.
         self._on_trait_change({'name': 'vmin', 'new': self.vmin})
         self._on_trait_change({'name': 'opacity', 'new': self.opacity})
-        self._on_trait_change({'name': 'cmap', 'new': self.cmap})
+        self._on_cmap_change()
 
         self.observe(self._on_trait_change, type='change')
 
@@ -924,13 +926,13 @@ class ImageLayer(HasTraits):
     def _check_cmap(self, proposal):
         if isinstance(proposal['value'], str):
             if proposal['value'] not in VALID_COLORMAPS:
-                raise ValueError('Colormap should be one of ' + '/'.join(VALID_COLORMAPS))
+                raise ValueError('Colormap should be one of ' + '/'.join(VALID_COLORMAPS) + ' (got {0})'.format(proposal['value']))
             return cm.get_cmap(proposal['value'])
         elif not isinstance(proposal['value'], Colormap):
             raise TypeError('cmap should be set to a Matplotlib colormap')
         else:
             if proposal['value'].name not in VALID_COLORMAPS:
-                raise ValueError('Colormap should be one of ' + ', '.join(VALID_COLORMAPS))
+                raise ValueError('Colormap should be one of ' + ', '.join(VALID_COLORMAPS) + ' (got {0})'.format(proposal['value'].name))
             return proposal['value']
 
     def _initialize_layer(self):
@@ -950,10 +952,12 @@ class ImageLayer(HasTraits):
 
     @observe('cmap')
     def _on_cmap_change(self, *value):
-        self.parent._send_msg(event='image_layer_set',
+        self._cmap_version += 1
+        self.parent._send_msg(event='image_layer_cmap',
                               id=self.id,
                               setting='colorMapperName',
-                              value=self.cmap.name)
+                              cmap=self.cmap.name,
+                              version=self._cmap_version)
 
     def _on_trait_change(self, changed):
 

--- a/pywwt/nbextension/static/wwt_json_api.js
+++ b/pywwt/nbextension/static/wwt_json_api.js
@@ -193,6 +193,7 @@ function wwt_apply_json_message(wwt, msg) {
 
       layer = wwt.loadFits(msg['url']);
       layer._stretch_version = 0;
+      layer._cmap_version = 0;
 
       wwt.layers[msg['id']] = layer;
       break;
@@ -226,6 +227,23 @@ function wwt_apply_json_message(wwt, msg) {
 
       }
       break;
+
+      case 'image_layer_cmap':
+
+        // See image_layer_stretch for why we need to do what we do below
+
+        var layer = wwt.layers[msg['id']];
+
+        if (layer.get_imageSet() == null) {
+          setTimeout(function(){ wwt_apply_json_message(wwt, msg); }, 200);
+        } else {
+          if (msg['version'] > layer._cmap_version) {
+            layer.set_colorMapperName(msg['cmap']);
+            layer._cmap_version = msg['version'];
+          }
+
+        }
+        break;
 
     case 'image_layer_set':
 


### PR DESCRIPTION
This is a companion PR to https://github.com/WorldWideTelescope/wwt-web-client/pull/244 - it adds a ``cmap`` property for image layers, and also exposes it in the controls widgets for the image layer.

<img width="877" alt="Screenshot 2019-10-01 at 00 16 59" src="https://user-images.githubusercontent.com/314716/65923425-d3f8fb00-e3e0-11e9-9262-38ece2657119.png">

This can be reviewed, but shouldn't be merged until https://github.com/WorldWideTelescope/wwt-web-client/pull/244 is also merged. The tests might fail for now as a result.