### PR TITLE
Include image colormap selection in JSON serialization

### DIFF
--- a/pywwt/layers.py
+++ b/pywwt/layers.py
@@ -1037,9 +1037,12 @@ class ImageLayer(HasTraits):
                 state['settings'][wwt_name] = trait.get(self)
 
         if self.vmin is not None and self.vmax is not None:
-            state['stretch_info'] = {'vmin': self.vmin,
-                                     'vmax': self.vmax,
-                                     'stretch':VALID_STRETCHES.index(self.stretch)}
+            state['stretch_info'] = {
+                'vmin': self.vmin,
+                'vmax': self.vmax,
+                'stretch': VALID_STRETCHES.index(self.stretch),
+                'cmap': self.cmap.name,
+            }
 
         return state
 

--- a/pywwt/nbextension/static/interactive_figure/interactive_figure.js
+++ b/pywwt/nbextension/static/interactive_figure/interactive_figure.js
@@ -167,10 +167,11 @@ function loadImageLayer(layerInfo) {
     var id = layerInfo['id'];
     var url = 'data/' + id + '.fits';
     var onFitsLoad = function (layer) {
-        var stertchInfo = layerInfo['stretch_info'];
-        wwtLayer.setImageScale(stertchInfo['stretch'],
-                               stertchInfo['vmin'],
-                               stertchInfo['vmax']);
+        var stretchInfo = layerInfo['stretch_info'];
+        wwtLayer.setImageScale(stretchInfo['stretch'],
+                               stretchInfo['vmin'],
+                               stretchInfo['vmax']);
+        wwtLayer.set_colorMapperName(stretchInfo['cmap']);
         layer.getFitsImage().transparentBlack = false;
         var settings = layerInfo['settings'];
         for (name in settings) {

--- a/pywwt/tests/test_serialization.py
+++ b/pywwt/tests/test_serialization.py
@@ -382,6 +382,7 @@ def test_image_setting_serialization():
     layer.opacity = 0.3
     layer.vmin = -1
     layer.vmax = 1
+    layer.cmap = 'plasma'
     layer_state = widget.quick_serialize()['layers'][0]
 
     assert layer_state['id'] == layer.id
@@ -390,6 +391,7 @@ def test_image_setting_serialization():
     assert layer_state['stretch_info']['vmin'] == -1
     assert layer_state['stretch_info']['vmax'] == 1
     assert layer_state['stretch_info']['stretch'] == 0
+    assert layer_state['stretch_info']['cmap'] == 'plasma'
 
     assert 'settings' in layer_state
     settings = layer_state['settings']


### PR DESCRIPTION
<!-- Thank you for your pull request! Please summarize it with the following form. -->

### Overview

<!-- briefly describe the purpose of the pull request here;
    mention any closed issues; see https://help.github.com/articles/closing-issues-using-keywords/ -->

When we added colormap selection to images, the new parameter wasn't added to the set of fields that got serialized to JSON. Just went ahead and fixed it rather than filing an issue.

### Checklist

<!-- Go ahead and remove any of the following checkboxes if they truly do not
    apply to your proposed changes. -->

- [x] Changed code has some test coverage (or justify why not)
- [ ] Changes in functionality documented (or justify why not)
- [ ] Changes summarized in `CHANGES.rst` file, if they merit mention in release notes

Not documented since it's part of serialization Just Working. Covered in CHANGES.rst as part of the cmap addition.