### PR TITLE
Fix compatibility with Jupyter Lab 2.0

### DIFF
--- a/lib/wwt.js
+++ b/lib/wwt.js
@@ -61,6 +61,9 @@ var WWTView = widgets.DOMWidgetView.extend({
         this.model.on('msg:custom', this.handle_custom_message, this);
     },
 
+    // Note: processPhosphorMessage is needed for Jupyter Lab <2 and
+    // processLuminoMessage is needed for Jupyter Lab 2.0+
+
     processPhosphorMessage: function(msg) {
         // We listen for phosphor resize events so that when Jupyter Lab is
         // used, we adjust the canvas size to the tab/panel in Jupyter Lab.
@@ -73,6 +76,19 @@ var WWTView = widgets.DOMWidgetView.extend({
             break;
         }
     },
+
+    processLuminoMessage: function(msg) {
+      // We listen for lumino resize events so that when Jupyter Lab is
+      // used, we adjust the canvas size to the tab/panel in Jupyter Lab.
+      // See relayout for more details.
+      WWTView.__super__.processLuminoMessage.apply(this, arguments);
+      switch (msg.type) {
+      case 'resize':
+      case 'after-show':
+          this.relayout();
+          break;
+      }
+  },
 
     relayout: function() {
         // Only do resizing if we are not in the notebook context but in a

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "clean:nbextension": "rimraf pywwt/nbextension/static/index.js"
   },
   "dependencies": {
-    "@jupyter-widgets/base": "^2.0.1"
+    "@jupyter-widgets/base": "^2  || ^3"
   },
   "devDependencies": {
     "rimraf": "^2.6.2",


### PR DESCRIPTION
This should in principle fix compatibility with Jupyter Lab 2.0 once ipyevents is fixed and a new version of ipywidgets is released. It still doesn't work for me but I think (based on the error messages) this is an ipyevents issue, or related dependency.