### PR TITLE
Work on improving Jupyter behavior with multiple views and view resets

### DIFF
--- a/frontend/lib/wwt.js
+++ b/frontend/lib/wwt.js
@@ -1,3 +1,40 @@
+// The main WWT ipywidgets implementation.
+//
+// The most important thing to remember about this implementation is that
+// IPywidgets has a model/view breakdown: on the JavaScript/browser side, you
+// can have multiple "views" of one underlying "model", which in turn
+// synchronizes its state with a Python kernel using Jupyter's comms.
+//
+// In most cases, there will be only one view per model, but there is at least
+// one important exception: in JupyterLab, you can create a WWT viewer in a
+// Python notebook, then right-click and "Create a new view" of it to pop it
+// open into a new JupyterLab frame. This is great for usability since it
+// prevents the WWT view from scrolling off the page as you work in your
+// notebook.
+//
+// The problem is that due to the (current) WWT architecture, all of the widget
+// state is necessarily stored in the widget view, inside the WWT <iframe>. So
+// if you create a new view of an existing widget, we can't realistically ensure
+// that they stay in sync. This is especially tricky since we want the user to
+// be able to, say, get the current RA/dec of the WWT widget, which is simply
+// not a well-defined quantity if there are two different views active.
+//
+// My initial thought was that we could create one <iframe> and "warp" it
+// between views, but that turns out not to work because iframes are reloaded
+// when they're reparented in the DOM, destroying the WWT state.
+//
+// Given these constraints, our current approach is:
+//
+// - The model has an idea of the "current" view, which is currently simply the
+//   one that was most recently created that still exists.
+//
+// - Queries for parameters such as the current RA/dec are understood to refer
+//   to the current view.
+//
+// - New views are understood to be created as "clean slates" compared to
+//   preexisting views. We could try to inherit properties of the current view,
+//   but don't right now.
+
 var widgets = require('@jupyter-widgets/base');
 var _ = require("underscore");
 
@@ -19,44 +56,179 @@ var WWTModel = widgets.DOMWidgetModel.extend({
         _fov : 60.0,
         _datetime : '2017-03-09T16:30:00',
 
-    })
-});
-
-var WWTView = widgets.DOMWidgetView.extend({
+    }),
 
     initialize: function() {
-
-        // We use an iframe to show WorldWideTelescope, because it does not
-        // otherwise support having multiple instances running on the same
-        // page. We use the same HTML file as for the Qt client.
-        var div = document.createElement("div");
+        WWTModel.__super__.initialize.apply(this, arguments);
 
         // NOTE: we deliberately call the following twice to make sure that it
-        // is properly set - not completely sure why this is.
-        this.wwt_base_url = require('@jupyterlab/coreutils').PageConfig.getBaseUrl();
-        this.wwt_base_url = require('@jupyterlab/coreutils').PageConfig.getBaseUrl();
+        // is properly set, due to a caching bug in some versions of JupyterLab.
+        this.wwtBaseUrl = require('@jupyterlab/coreutils').PageConfig.getBaseUrl();
+        this.wwtBaseUrl = require('@jupyterlab/coreutils').PageConfig.getBaseUrl();
 
-        div.innerHTML = "<iframe width='100%' height='400' style='border: none;' src='" + this.wwt_base_url + "wwt/wwt.html'></iframe>"
-
-        this.el.appendChild(div);
-
-        WWTView.__super__.initialize.apply(this, arguments);
+        this.wwtViewDivs = [];
+        this.currentViewWindowId = 0;
+        this.nextViewWindowId = 1;
 
         // Monitor the view data so that we can transmit updates. We handle the
         // clock specially so as not to be sending updates continually.
         this.lastClockUpdate = 0;
         var self = this;
-        setInterval(function () { self.update_view_data(); }, 150);
+        setInterval(function () { self.updateViewData(); }, 150);
+        this.on('msg:custom', this.handleCustomMessage, this);
     },
 
-    _try_init_wwt_window: function() {
-        iframe = this.el.getElementsByTagName('iframe')[0];
-        if (iframe != null) {
-            this.wwt_window = iframe.contentWindow;
-            return true;
-        } else {
-            return false; // Not ready yet
+    // This function is called very frequently, so we must make sure to not send
+    // updates unless something has changed. (If you're viewing a notebook
+    // running on a remote server, that's constant cross-internet traffic!)
+    // Ideally we'd be triggered on updates rather than polling, but we're not
+    // well set up to do that right now, especially given the possible presence
+    // of multiple views.
+    updateViewData: function () {
+        var window = this.getCurrentWindow();
+        if (window === null) {
+            return;
         }
+
+        var needUpdate = false;
+
+        if (this.get('_ra') != window.wwt.getRA()) {
+            this.set({ '_ra': window.wwt.getRA() });
+            needUpdate = true;
+        }
+
+        if (this.get('_dec') != window.wwt.getDec()) {
+            this.set({ '_dec': window.wwt.getDec() });
+            needUpdate = true;
+        }
+
+        if (this.get('_fov') != window.wwt.get_fov()) {
+            this.set({ '_fov': window.wwt.get_fov() });
+            needUpdate = true;
+        }
+
+        // By default, the clock is always ticking. We throttle updates by having
+        // the listener extrapolate the clock itself given reference times and the
+        // "time rate".
+        //
+        // For compatibility reasons, the engine's time must be exposed using a
+        // trait named `_datetime`. If any of the time-related parameters are
+        // changed discontinuously, set lastClockUpdate to 0 to force an update.
+        var nowUnixMs = Date.now();
+        var updateTimeParams = (nowUnixMs - this.lastClockUpdate) > 60000;
+
+        if (updateTimeParams) {
+            var stc = window.wwtlib.SpaceTimeController;
+            var rate = stc.get_timeRate();
+
+            if (!stc.get_syncToClock()) {
+                // When time is paused by setting syncToClock to false, the WWT
+                // "rate" remains unchanged, but as far as the Python layer is
+                // concerned, the rate should be 0.
+                rate = 0.0;
+            }
+
+            this.set({
+                '_datetime': stc.get_now().toISOString(),
+                '_systemDatetime': (new Date()).toISOString(),
+                '_timeRate': rate,
+            });
+
+            this.lastClockUpdate = nowUnixMs;
+            needUpdate = true;
+        }
+
+        if (needUpdate) {
+            this.save_changes();
+        }
+    },
+
+    // Make sure that we fully sync up our state with the current view. At the
+    // moment, all we need to do is ensure that the clock is resynced.
+    // Everything else is stateless.
+    forceViewDataUpdate: function() {
+        this.lastClockUpdate = 0;
+    },
+
+    // The views do all of the real work in message processing, but we do keep
+    // an eye out to know when to force a clock update.
+    handleCustomMessage: function(msg) {
+        switch(msg['event']) {
+            case 'load_tour':
+            case 'resume_tour':
+            case 'pause_tour':
+            case 'resume_time':
+            case 'pause_time':
+            case 'set_datetime':
+                this.forceViewDataUpdate();
+                break;
+        }
+    },
+
+    // There is a `views` attribute that is a dict of promises to known views,
+    // but for our purposes it's easiest to DIY, since there is a lot of
+    // unpredictable timing having to do with iframe creation and destruction.
+    registerViewDiv: function(div) {
+        this.wwtViewDivs.splice(0, 0, div);
+
+        // An update should be forced by getCurrentWindow() noticing that we're
+        // looking at a new div, but it doesn't hurt to double-force.
+        this.forceViewDataUpdate();
+    },
+
+    // Note that this will still work if multiple views are created and
+    // destroyed. It is hard to imagine that the list of divs will ever get long
+    // enough to be an issue. Famous last words?
+    getCurrentWindow: function() {
+        for (var i = 0; i < this.wwtViewDivs.length; i++) {
+            var iframe = this.wwtViewDivs[i].getElementsByTagName('iframe')[0];
+            if (!iframe)
+                continue;
+
+            var window = iframe.contentWindow;
+            if (!window)
+                continue;
+
+            if (!window.wwt)
+                continue;
+
+            // OK, we have our winner! If it is a different view than before,
+            // make sure to force-update the model values. Hiding and re-showing
+            // the same div reloads the WWT iframe, which causes the engine
+            // state to be reset. So even if the active div hasn't changed, we
+            // might still need a force.
+
+            if (window.wwtWidgetModelId === undefined) {
+                window.wwtWidgetModelId = this.nextViewWindowId;
+                this.nextViewWindowId += 1;
+            }
+
+            if (window.wwtWidgetModelId != this.currentViewWindowId) {
+                this.currentViewWindowId = window.wwtWidgetModelId;
+                this.forceViewDataUpdate();
+            }
+
+            return window;
+        }
+
+        return null;
+    },
+});
+
+// Note that a view can be hidden, e.g. by clicking to the left of its
+// containing cell. This removes the view element from the DOM but does not
+// destroy the element. However, re-adding an iframe to the DOM causes it to
+// reload, so hiding and re-showing a WWT view causes its internal state to be
+// reset :-(
+var WWTView = widgets.DOMWidgetView.extend({
+    initialize: function() {
+        // TODO: I this could just be put in render now?
+        var div = document.createElement("div");
+        div.innerHTML = "<iframe width='100%' height='400' style='border: none;' src='" + this.model.wwtBaseUrl + "wwt/wwt.html'></iframe>"
+        this.el.appendChild(div);
+        this.model.registerViewDiv(div);
+
+        WWTView.__super__.initialize.apply(this, arguments);
     },
 
     render: function() {
@@ -147,113 +319,59 @@ var WWTView = widgets.DOMWidgetView.extend({
         iframe.height = height - 10;
     },
 
+    // Get the WWT window, if it is actually fully initialized. Note that
+    // if this widget view is hidden and then re-shown, the iframe will reload,
+    // and the contentWindow will acquire a new value. So we can't cache too
+    // aggressively.
+    tryGetWindow: function() {
+        var iframe = this.el.getElementsByTagName('iframe')[0];
+        if (!iframe)
+            return null;
+
+        var window = iframe.contentWindow;
+        if (!window)
+            return null;
+
+        if (!window.wwt)
+            return null; // not fully initialized yet
+
+        return window;
+    },
+
     handle_custom_message: function(msg) {
-        if (this.wwt_window == null && !this._try_init_wwt_window()) {
+        var window = this.tryGetWindow();
+        if (!window) {
+            // TODO? we could queue up messages and replay them once the window
+            // is ready. But if we've been hidden, that might take a long time
+            // to happen. And it's not clear how we'd find out *when* the window
+            // is ready anyway.
             return;
         }
 
         if (msg['url'] != null && msg['url'].slice(4) == '/wwt') {
-            msg['url'] = this.wwt_base_url + msg['url'];
+            msg['url'] = this.model.wwtBaseUrl + msg['url'];
         }
 
         // If the user has created a view for our widget and then hidden it, our
         // iframe gets removed and all sorts of things stop working (e.g.,
         // Chrome will refuse to send XMLHttpRequests anymore, and Firefox won't
         // set timeouts). If we let exceptions from these operations bubble up,
-        // they break the code that applies widget events to *all* views, which
-        // then breaks the JupyterLab use case of (1) setting up a WWT widget,
-        // (2) creating a view of it in a separate tab, and then (3) hiding the
-        // view in the original notebook, because the second view will never
-        // receive any messages. We should handle things better when widgets get
-        // hidden, but in the meantime, try to keep things limping along by
-        // swallowing exceptions here. Note that this approach will mean that
-        // the two views will get out of sync regarding, e.g., image layers that
-        // have been loaded.
+        // they break the code that applies widget events to *all* views We
+        // should handle things better when widgets get hidden, but in the
+        // meantime, try to keep things limping along by swallowing exceptions
+        // here.
 
         try {
-            this.wwt_window.wwt_apply_json_message(this.wwt_window.wwt, msg);
-
-            switch(msg['event']) {
-                case 'load_tour':
-                case 'resume_tour':
-                case 'pause_tour':
-                case 'resume_time':
-                case 'pause_time':
-                case 'set_datetime':
-                    this.lastClockUpdate = 0;
-                    break;
-            }
+            window.wwt_apply_json_message(window.wwt, msg);
         } catch (e) {
             console.log('failed to process custom_message for a pyWWT Jupyter widget view:');
             console.log(msg);
             (console.error || console.log).call(console, e.stack || e);
         }
     },
-
-    // This function is called very frequently, so we make sure to not send
-    // updates unless something has changed. Ideally we'd be triggered on
-    // updates rather than polling, but we're not well set up to do that right
-    // now.
-    update_view_data: function () {
-        if ((this.wwt_window == null && !this._try_init_wwt_window()) || !this.wwt_window.wwt) {
-            return;
-        }
-
-        var needUpdate = false;
-
-        if (this.model.get('_ra') != this.wwt_window.wwt.getRA()) {
-            this.model.set({ '_ra': this.wwt_window.wwt.getRA() });
-            needUpdate = true;
-        }
-
-        if (this.model.get('_dec') != this.wwt_window.wwt.getDec()) {
-            this.model.set({ '_dec': this.wwt_window.wwt.getDec() });
-            needUpdate = true;
-        }
-
-        if (this.model.get('_fov') != this.wwt_window.wwt.get_fov()) {
-            this.model.set({ '_fov': this.wwt_window.wwt.get_fov() });
-            needUpdate = true;
-        }
-
-        // By default, the clock is always ticking. We throttle updates by having
-        // the listener extrapolate the clock itself given reference times and the
-        // "time rate".
-        //
-        // For compatibility reasons, the engine's time must be exposed using a
-        // trait named `_datetime`. If any of the time-related parameters are
-        // changed discontinuously, set lastClockUpdate to 0 to force an update.
-        var nowUnixMs = Date.now();
-        var updateTimeParams = (nowUnixMs - this.lastClockUpdate) > 60000;
-
-        if (updateTimeParams) {
-            var stc = this.wwt_window.wwtlib.SpaceTimeController;
-            var rate = stc.get_timeRate();
-
-            if (!stc.get_syncToClock()) {
-                // When time is paused by setting syncToClock to false, the WWT
-                // "rate" remains unchanged, but as far as the Python layer is
-                // concerned, the rate should be 0.
-                rate = 0.0;
-            }
-
-            this.model.set({
-                '_datetime': stc.get_now().toISOString(),
-                '_systemDatetime': (new Date()).toISOString(),
-                '_timeRate': rate
-            });
-
-            this.lastClockUpdate = nowUnixMs;
-            needUpdate = true;
-        }
-
-        if (needUpdate) {
-            this.touch();
-        }
-    }
 });
 
 module.exports = {
     WWTModel: WWTModel,
-    WWTView: WWTView
+    WWTView: WWTView,
 };

--- a/frontend/lib/wwt.js
+++ b/frontend/lib/wwt.js
@@ -55,7 +55,7 @@ var WWTModel = widgets.DOMWidgetModel.extend({
         _dec : 0.0,
         _fov : 60.0,
         _datetime : '2017-03-09T16:30:00',
-
+        _viewConnected : false,
     }),
 
     initialize: function() {
@@ -85,12 +85,22 @@ var WWTModel = widgets.DOMWidgetModel.extend({
     // well set up to do that right now, especially given the possible presence
     // of multiple views.
     updateViewData: function () {
+        var needUpdate = false;
         var window = this.getCurrentWindow();
-        if (window === null) {
-            return;
+        var viewConnected = (window !== null);
+
+        if (this.get('_viewConnected') != viewConnected) {
+            this.set({ '_viewConnected': viewConnected });
+            needUpdate = true;
         }
 
-        var needUpdate = false;
+        if (window === null) {
+            if (needUpdate) {
+                this.save_changes();
+            }
+
+            return;
+        }
 
         if (this.get('_ra') != window.wwt.getRA()) {
             this.set({ '_ra': window.wwt.getRA() });

--- a/pywwt/nbextension/static/wwt.html
+++ b/pywwt/nbextension/static/wwt.html
@@ -32,8 +32,14 @@
       var wwt_ready = 0;
 
       function initialize() {
-        // The true enables WebGL
-        wwt = wwtlib.WWTControl.initControlParam("WWTCanvas", true);
+        wwt = wwtlib.WWTControl.initControl6(
+          'WWTCanvas',  // divId
+          true,  // startRenderLoop
+          -28.9,  // startLat (deg) -- galactic center
+          93.6,  // startLng (deg) -- RA = 360 - lng
+          240.0,  // startZoom -- 6 * (viewport height in deg)
+          'Sky',  // startMode
+        );
         wwt.add_ready(wwtReady);
         wwt.add_ready(keyScroll);
       }

--- a/pywwt/tests/test_qt_widget.py
+++ b/pywwt/tests/test_qt_widget.py
@@ -56,10 +56,8 @@ def test_full(tmpdir, wwt_qt_client_isolated):
     # Step 0
 
     wwt.foreground_opacity = 1.
-
-    # The crosshairs are currently broken on Mac/Linux but work on Windows.
-    # For consistency, we turn it off here so that the results are the same
-    # on all platforms.
+    gc = SkyCoord(0, 0, unit=('deg', 'deg'), frame='icrs')
+    wwt.center_on_coordinates(gc, 60 * u.deg)
     wwt.crosshairs = False
 
     wait_for_test(wwt, WAIT_TIME, for_render=True)
@@ -84,7 +82,6 @@ def test_full(tmpdir, wwt_qt_client_isolated):
     wwt.constellation_boundary_color = 'red'
     wwt.constellation_figure_color = 'green'
     wwt.constellation_selection_color = 'blue'
-
     wwt.constellation_boundaries = True
     wwt.constellation_figures = True
 
@@ -97,8 +94,6 @@ def test_full(tmpdir, wwt_qt_client_isolated):
     # Step 3
 
     wwt.constellation_selection = True
-
-    wwt.crosshairs = False
     wwt.ecliptic = True
     wwt.grid = True
 


### PR DESCRIPTION
<!-- Thank you for your pull request! Please summarize it with the following form. -->

### Overview

<!-- briefly describe the purpose of the pull request here;
    mention any closed issues; see https://help.github.com/articles/closing-issues-using-keywords/ -->

Try to fix up the Jupyter widget behavior in the presence of multiple views, and the fact that views can be reset more or less at whim since hiding a widget view causes the underlying WWT iframe to be reset.

### Checklist

<!-- Go ahead and remove any of the following checkboxes if they truly do not
    apply to your proposed changes. -->

- [ ] Changed code has some test coverage (or justify why not)
  - Not really :-( This area of functionality doesn't really have test infrastructure right now.
- [ ] Changes in functionality documented (or justify why not)
  - No behavior changes in standard usage; this should basically just cause more robust/reliable behavior in funky situations