### PR TITLE
pywwt/nbextension/static/wwt.html: remove trailing comma

### DIFF
--- a/pywwt/nbextension/static/wwt.html
+++ b/pywwt/nbextension/static/wwt.html
@@ -27,18 +27,17 @@
     </script>
 
     <script>
-
       var wwt;
       var wwt_ready = 0;
 
       function initialize() {
         wwt = wwtlib.WWTControl.initControl6(
           'WWTCanvas',  // divId
-          true,  // startRenderLoop
+          true,   // startRenderLoop
           -28.9,  // startLat (deg) -- galactic center
-          93.6,  // startLng (deg) -- RA = 360 - lng
+          93.6,   // startLng (deg) -- RA = 360 - lng
           240.0,  // startZoom -- 6 * (viewport height in deg)
-          'Sky',  // startMode
+          'Sky'   // startMode
         );
         wwt.add_ready(wwtReady);
         wwt.add_ready(keyScroll);


### PR DESCRIPTION
### Overview

It looks like the Qt JavaScript interpreter on macOS doesn't like the trailing comma in our function call, causing the embedded webpage to break. If correct this is a little scary in terms of what it means for our ability to use remotely advanced JS constructs, but let's see if this keeps things going for now.

Also some general whitespace futzing, but the key change is to the `startMode` line.

### Checklist

- [x] Changed code has some test coverage (or justify why not)
