### PR TITLE
Bundle the research app with the Jupyter extension and port the ipywidgets implementation to use it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,9 @@
 /docs/_static/embed-bundle.js
 /docs/_static/embed-bundle.js.map
-/pywwt/labextension
+/pywwt/labextension/
 /pywwt/nbextension/static/index.js
 /pywwt/nbextension/static/index.js.map
+/pywwt/web_static/research/
 
 # Compiled files
 *.py[cod]

--- a/frontend/lib/widget.js
+++ b/frontend/lib/widget.js
@@ -1,4 +1,10 @@
-// The main WWT ipywidgets implementation.
+// The main WWT ipywidgets (Jupyter widget) implementation.
+//
+// This used to use a hand-coded interface to the WWT engine, but now uses the
+// "research app" and its standardized messaging framework. This package is
+// needed to bridge the research app and ipywidgets. Our recommended way to use
+// WWT in Jupyter is now to use the app extension, not this widget, but needs
+// might vary.
 //
 // The most important thing to remember about this implementation is that
 // IPywidgets has a model/view breakdown: on the JavaScript/browser side, you
@@ -21,7 +27,9 @@
 //
 // My initial thought was that we could create one <iframe> and "warp" it
 // between views, but that turns out not to work because iframes are reloaded
-// when they're reparented in the DOM, destroying the WWT state.
+// when they're reparented in the DOM, destroying the WWT state. For the same
+// reason, the WWT state can also be destroyed if you hide and un-hide a single
+// widget view, unfortunately.
 //
 // Given these constraints, our current approach is:
 //
@@ -35,14 +43,14 @@
 //   preexisting views. We could try to inherit properties of the current view,
 //   but don't right now.
 //
-// Communication between this frontend and the Jupyter backend (presumably
-// pywwt, but in principle other backends could be added) is done using
-// ipywidgets "custom" messages. Both the WWTModel and the WWTViews can listen
-// for these messages and react to them. Because the actual WWT viewer logic is
-// all embedded inside an <iframe>, the main role of the code here is to relay
-// those messages to iframe implementation using the `wwt_apply_json_message`
-// function that is set up by the widget HTML <iframe> implementation. The
-// message inteface is documented as [@wwtelescope/research-app-messages].
+// Communication between the WWT app and the kernel (presumably Python/pywwt,
+// but in principle other backends could be added) is done using JSON-compatible
+// messages, documented as [@wwtelescope/research-app-messages]. The ipywidgets
+// implementation is particularly gnarly because (1) each "widget" might
+// actually talk to multiple apps, due to the model-view architecture of
+// ipywidgets, and (2) each widget will receive messages from other widgets, due
+// to the way that the Web messaging spec works. This layer has to do a lot of
+// work to pretend to the kernel that it's only talking to one app.
 //
 // [@wwtelescope/research-app-messages]: https://docs.worldwidetelescope.org/webgl-reference/latest/apiref/research-app-messages/modules/classicpywwt.html
 
@@ -54,12 +62,13 @@ var version = require('./index').version;
 // The widget model class.
 //
 // For each ipywidget widget, there is one model in JS that synchronizes its
-// state with a Python model over Jupyter's comms. Our implementation is
-// unusually gnarly because the widget state is actually stored in the *view*,
-// inside the WWT iframe, as described above.
+// state with a Python model over Jupyter's comms. Since WWT's state is actually
+// in the view, the model is mostly concerned about relaying messages correctly.
+// Which is a hairy busines, because not only does our one widget potentially
+// have multiple views, but there are also potentially multiple active widgets,
+// and we'll see all of their messages.
 var WWTModel = widgets.DOMWidgetModel.extend({
     defaults: _.extend(widgets.DOMWidgetModel.prototype.defaults(), {
-
         _model_name: 'WWTModel',
         _model_module: 'pywwt',
         _model_module_version: version,
@@ -68,11 +77,7 @@ var WWTModel = widgets.DOMWidgetModel.extend({
         _view_module: 'pywwt',
         _view_module_version: version,
 
-        _ra: 0.0,
-        _dec: 0.0,
-        _fov: 60.0,
-        _datetime: '2017-03-09T16:30:00',
-        _viewConnected: false,
+        _appUrl: ''
     }),
 
     initialize: function () {
@@ -83,163 +88,151 @@ var WWTModel = widgets.DOMWidgetModel.extend({
         this.wwtBaseUrl = require('@jupyterlab/coreutils').PageConfig.getBaseUrl();
         this.wwtBaseUrl = require('@jupyterlab/coreutils').PageConfig.getBaseUrl();
 
-        this.wwtViewDivs = [];
-        this.currentViewWindowId = 0;
-        this.nextViewWindowId = 1;
+        this._currentView = null;
+        this._nextViewSeqNumber = 0;
 
-        // Monitor the view data so that we can transmit updates. We handle the
-        // clock specially so as not to be sending updates continually.
-        this.lastClockUpdate = 0;
-        var self = this;
-        setInterval(function () { self.updateViewData(); }, 150);
-        this.on('msg:custom', this.handleCustomMessage, this);
+        // We're not going to even try to honor updates to this property.
+        const appUrl = this.canonicalizeUrl(this.get('_appUrl'));
+        this._appOrigin = new URL(appUrl).origin;
+
+        // Listen for events emerging from the kernel, via ipywidgets's "custom"
+        // message API.
+        this.on('msg:custom', this.processIpyWidgetsMessage, this);
+
+        // Listen for events emerging from the apps. Note that this function will
+        // receive messages from *all* views of *all* instantiated widgets, so
+        // it needs to be picky about which events it pays attention to.
+
+        const self = this;
+
+        window.addEventListener(
+            'message',
+            function (event) { self.processDomWindowMessage(event); },
+            false
+        );
     },
 
-    // This function is called very frequently, so we must make sure to not send
-    // updates unless something has changed. (If you're viewing a notebook
-    // running on a remote server, that's constant cross-internet traffic!)
-    // Ideally we'd be triggered on updates rather than polling, but we're not
-    // well set up to do that right now, especially given the possible presence
-    // of multiple views.
-    updateViewData: function () {
-        var needUpdate = false;
-        var window = this.getCurrentWindow();
-        var viewConnected = (window !== null);
-
-        if (this.get('_viewConnected') != viewConnected) {
-            this.set({ '_viewConnected': viewConnected });
-            needUpdate = true;
+    // The kernel can generate partial URLs, but doesn't (and can't) know the
+    // full URL where data are ultimately exposed. So in various places we need
+    // to edit URLs emerging from the client to make them complete.
+    canonicalizeUrl: function (url) {
+        // Sketchy heuristic to deal with the Jupyter "base URL", which still
+        // isn't an absolute URL. It's a URL path used by multi-user Jupyter
+        // servers and the like. The Python kernel code can determine the base
+        // URL on its own, but it requires some super hackery (reading various
+        // magical JSON config files and making API calls).
+        if (url.slice(4) == '/wwt') {
+            url = this.wwtBaseUrl + url;
         }
 
-        if (window === null) {
-            if (needUpdate) {
-                this.save_changes();
-            }
+        return new URL(url, location.toString()).toString();
+    },
 
+    // Get a unique ID and sequence number for distinguishing views. Note that
+    // while each model might have multiple views, there might also be multiple
+    // widget models too, and we have to distinguish them all.
+    mintViewIds: function() {
+        var seq = this._nextViewSeqNumber;
+        this._nextViewSeqNumber++;
+        return [this.model_id + "v" + seq, seq];
+    },
+
+    // Called by a widget view when its app is ready to respond to messages.
+    onViewReady: function(view) {
+        // By definition, this is the most recent view to become ready,
+        // so it should start receiving messages.
+
+        if (this._currentView === null) {
+            // This is the first view to become ready at all. Signal to the
+            // kernel that we are ready to process messages.
+            this.send({
+                type: 'wwt_jupyter_widget_ready'
+            });
+        }
+
+        this._currentView = view;
+    },
+
+    // Relay a message from the kernel to the active view. In order to keep
+    // things tractable, we only route messages to the "current" view. For
+    // instance, if the client were to issue a data-request message and we
+    // routed it to multiple views, we'd get multiple responses, with no
+    // sensible way to know which to prefer.
+    processIpyWidgetsMessage: function (msg) {
+        if (this._currentView === null) {
+            // We could queue up messages here. The kernel "shouldn't" send us
+            // any messages until a view is ready, but it's always possible that
+            // all of our views will go away after startup anyway.
+            console.warn("pywwt jupyer widget: dropping message on floor", msg);
             return;
         }
 
-        if (this.get('_ra') != window.wwt.getRA()) {
-            this.set({ '_ra': window.wwt.getRA() });
-            needUpdate = true;
+        // The "official" implementation here is in
+        // @wwtelescope/research-app-messages in
+        // classic_pywwt.applyBaseUrlIfApplicable.
+        if (msg['url']) {
+            msg['url'] = this.canonicalizeUrl(msg['url']);
         }
 
-        if (this.get('_dec') != window.wwt.getDec()) {
-            this.set({ '_dec': window.wwt.getDec() });
-            needUpdate = true;
-        }
-
-        if (this.get('_fov') != window.wwt.get_fov()) {
-            this.set({ '_fov': window.wwt.get_fov() });
-            needUpdate = true;
-        }
-
-        // By default, the clock is always ticking. We throttle updates by having
-        // the listener extrapolate the clock itself given reference times and the
-        // "time rate".
+        // If there are multiple active widgets (models+views), our listener
+        // will get messages from all of them. In order to be able to
+        // disambiguate, we need to make sure that threadIds are uniquified by
+        // widget.
         //
-        // For compatibility reasons, the engine's time must be exposed using a
-        // trait named `_datetime`. If any of the time-related parameters are
-        // changed discontinuously, set lastClockUpdate to 0 to force an update.
-        var nowUnixMs = Date.now();
-        var updateTimeParams = (nowUnixMs - this.lastClockUpdate) > 60000;
+        // On the other hand, we don't want to tag messages by *view*
+        // unique-ids: if we send a message to one view, then another view
+        // becomes active, then we get a reply to the earlier message, we should
+        // still honor that reply.
+        if (msg['threadId']) {
+            msg['threadId'] = this.model_id + "|" + msg['threadId'];
+        }
 
-        if (updateTimeParams) {
-            var stc = window.wwtlib.SpaceTimeController;
-            var rate = stc.get_timeRate();
+        this._currentView.relayIpyWidgetsMessage(msg);
+    },
 
-            if (!stc.get_syncToClock()) {
-                // When time is paused by setting syncToClock to false, the WWT
-                // "rate" remains unchanged, but as far as the Python layer is
-                // concerned, the rate should be 0.
-                rate = 0.0;
+    // Process messages from the WWT apps, potentially relaying them to the
+    // kernel.
+    //
+    // This is annoying because we're going to receive messages for all views
+    // associated with all widgets. We need to pay attention to the right ones.
+    //
+    // The message is relayed to the kernel using ipywidgets "custom" messages,
+    // which is basically trivial once we've dealt with the above.
+    processDomWindowMessage: function (event) {
+        var payload = event.data;
+
+        if (event.origin !== this._appOrigin)
+            return;
+
+        // Unsolicited messages will be tagged with a sessionId. These should
+        // match the sessionId associated with the "current" view -- the only
+        // way that we can sensibly work in the ipywidgets framework is to
+        // pretend non-current views don't exist.
+        //
+        // The ping-pong messages triggered by the views while waiting for the
+        // apps to get ready will have sessionIds that don't match this scheme,
+        // but that's OK because this function doesn't need to handle those
+        // messages.
+        if (payload['sessionId']) {
+            if (!this._currentView || payload['sessionId'] != this._currentView.wwtId) {
+                return;
+            }
+        }
+
+        // Reply messages will be tagged with a threadId. We should make sure that
+        // these are relevant to our widget (model ID) and un-munge our disambiguator.
+        if (payload['threadId']) {
+            const pieces = payload['threadId'].split('|');
+
+            if (pieces[0] != this.model_id) {
+                return;
             }
 
-            this.set({
-                '_datetime': stc.get_now().toISOString(),
-                '_systemDatetime': (new Date()).toISOString(),
-                '_timeRate': rate,
-            });
-
-            this.lastClockUpdate = nowUnixMs;
-            needUpdate = true;
+            payload['threadId'] = pieces.slice(1).join('|');
         }
 
-        if (needUpdate) {
-            this.save_changes();
-        }
-    },
-
-    // Make sure that we fully sync up our state with the current view. At the
-    // moment, all we need to do is ensure that the clock is resynced.
-    // Everything else is stateless.
-    forceViewDataUpdate: function () {
-        this.lastClockUpdate = 0;
-    },
-
-    // The views do all of the real work in message processing, but we do keep
-    // an eye out to know when to force a clock update.
-    handleCustomMessage: function (msg) {
-        switch (msg['event']) {
-            case 'load_tour':
-            case 'resume_tour':
-            case 'pause_tour':
-            case 'resume_time':
-            case 'pause_time':
-            case 'set_datetime':
-                this.forceViewDataUpdate();
-                break;
-        }
-    },
-
-    // There is a `views` attribute that is a dict of promises to known views,
-    // but for our purposes it's easiest to DIY, since there is a lot of
-    // unpredictable timing having to do with iframe creation and destruction.
-    registerViewDiv: function (div) {
-        this.wwtViewDivs.splice(0, 0, div);
-
-        // An update should be forced by getCurrentWindow() noticing that we're
-        // looking at a new div, but it doesn't hurt to double-force.
-        this.forceViewDataUpdate();
-    },
-
-    // Note that this will still work if multiple views are created and
-    // destroyed. It is hard to imagine that the list of divs will ever get long
-    // enough to be an issue. Famous last words?
-    getCurrentWindow: function () {
-        for (var i = 0; i < this.wwtViewDivs.length; i++) {
-            var iframe = this.wwtViewDivs[i].getElementsByTagName('iframe')[0];
-            if (!iframe)
-                continue;
-
-            var window = iframe.contentWindow;
-            if (!window)
-                continue;
-
-            if (!window.wwt)
-                continue;
-
-            // OK, we have our winner! If it is a different view than before,
-            // make sure to force-update the model values. Hiding and re-showing
-            // the same div reloads the WWT iframe, which causes the engine
-            // state to be reset. So even if the active div hasn't changed, we
-            // might still need a force.
-
-            if (window.wwtWidgetModelId === undefined) {
-                window.wwtWidgetModelId = this.nextViewWindowId;
-                this.nextViewWindowId += 1;
-            }
-
-            if (window.wwtWidgetModelId != this.currentViewWindowId) {
-                this.currentViewWindowId = window.wwtWidgetModelId;
-                this.forceViewDataUpdate();
-            }
-
-            return window;
-        }
-
-        return null;
-    },
+        this.send(payload);
+    }
 });
 
 // The pywwt ipywidget view implementation.
@@ -253,21 +246,93 @@ var WWTModel = widgets.DOMWidgetModel.extend({
 // reload, so hiding and re-showing a WWT view causes its internal state to be
 // reset :-(
 var WWTView = widgets.DOMWidgetView.extend({
-    initialize: function () {
-        // TODO: I this could just be put in render now?
-        var div = document.createElement("div");
-        div.innerHTML = "<iframe width='100%' height='400' style='border: none;' src='" + this.model.wwtBaseUrl + "wwt/widget/'></iframe>"
-        this.el.appendChild(div);
-        this.model.registerViewDiv(div);
+    render: function () {
+        this._appUrl = this.model.canonicalizeUrl(this.model.get('_appUrl'));
+        this._appOrigin = new URL(this._appUrl).origin;
 
-        WWTView.__super__.initialize.apply(this, arguments);
+        const ids = this.model.mintViewIds();
+        this.wwtId = ids[0];
+        this.seqNumber = ids[1];
+
+        var iframe = document.createElement('iframe');
+        // Pass our origin so that the iframe can validate the provenance of the
+        // messages that are posted to it. This isn't acceptable for real XSS
+        // prevention, but so long as the research app can't do anything on behalf
+        // of the user (which it can't right now because we don't even have
+        // "users"), that's OK.
+        iframe.src = this._appUrl + '?origin=' + encodeURIComponent(location.origin);
+        iframe.style.setProperty('height', '400px', '');
+        iframe.style.setProperty('width', '100%', '');
+        iframe.style.setProperty('border', 'none', '');
+
+        // 2021 June: Is this wrapper div still necessary?
+        var div = document.createElement('div');
+        div.appendChild(iframe);
+
+        this.el.appendChild(div);
+
+        // We need to ping the app to find out when it's ready to receive
+        // messages. While the model handles most of the messaging stuff, it's a
+        // lot easier to handle the ready polling here in the view.
+
+        this.ready = false;
+        const self = this;
+
+        window.addEventListener(
+            'message',
+            function (event) { self.processDomWindowMessage(event); },
+            false
+        );
+
+        this._pingerId = setInterval(function () { self.pingApp(); }, 100);
     },
 
-    render: function () {
-        // We pass all messages via msg:custom rather than look for trait events
-        // because we just want to use the same JSON messaging interface for
-        // the Qt widget and the Jupyter widget.
-        this.model.on('msg:custom', this.handleCustomMessage, this);
+    pingApp: function() {
+        // In principle we shouldn't get called once `ready` is true, but ...
+        if (!this.ready) {
+            var window = this.tryGetWindow();
+            if (window) {
+                window.postMessage({
+                    type: "wwt_ping_pong",
+                    threadId: this.wwtId,
+                    sessionId: this.wwtId,
+                }, this._appUrl);
+            }
+        }
+    },
+
+    // Process a message sent to the browser window. This function's only job is
+    // to look for a response to our ready ping from our particular app.
+    processDomWindowMessage: function (event) {
+        var payload = event.data;
+
+        if (event.origin !== this._appOrigin)
+            return;
+
+        if (this.ready)
+            return;
+
+        if (payload.type == "wwt_ping_pong" && payload.threadId == this.wwtId) {
+            // Our app is alive! In principle we should now deregister this
+            // event listener, but ... meh.
+            clearInterval(this._pingerId);
+            this._pingerId = null;
+            this.ready = true;
+            this.model.onViewReady(this);
+        }
+    },
+
+    // Called by the model when there's a message from the kernel that should go
+    // to this view. The model "shouldn't" give us any messages if/when our
+    // window is nonfunctional, but the window might always die underneath us.
+    relayIpyWidgetsMessage: function (msg) {
+        var window = this.tryGetWindow();
+        if (!window) {
+            // TODO? Tell the model that we failed?
+            return;
+        }
+
+        window.postMessage(msg, this._appUrl);
     },
 
     // Note: processPhosphorMessage is needed for Jupyter Lab <2 and
@@ -364,43 +429,8 @@ var WWTView = widgets.DOMWidgetView.extend({
         if (!window)
             return null;
 
-        if (!window.wwt)
-            return null; // not fully initialized yet
-
         return window;
-    },
-
-    handleCustomMessage: function (msg) {
-        var window = this.tryGetWindow();
-        if (!window) {
-            // TODO? we could queue up messages and replay them once the window
-            // is ready. But if we've been hidden, that might take a long time
-            // to happen. And it's not clear how we'd find out *when* the window
-            // is ready anyway.
-            return;
-        }
-
-        if (msg['url'] != null && msg['url'].slice(4) == '/wwt') {
-            msg['url'] = this.model.wwtBaseUrl + msg['url'];
-        }
-
-        // If the user has created a view for our widget and then hidden it, our
-        // iframe gets removed and all sorts of things stop working (e.g.,
-        // Chrome will refuse to send XMLHttpRequests anymore, and Firefox won't
-        // set timeouts). If we let exceptions from these operations bubble up,
-        // they break the code that applies widget events to *all* views. We
-        // should handle things better when widgets get hidden, but in the
-        // meantime, try to keep things limping along by swallowing exceptions
-        // here.
-
-        try {
-            window.wwt_apply_json_message(window.wwt, msg);
-        } catch (e) {
-            console.log('failed to process custom_message for a pyWWT Jupyter widget view:');
-            console.log(msg);
-            (console.error || console.log).call(console, e.stack || e);
-        }
-    },
+    }
 });
 
 module.exports = {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,6 +5,7 @@
   },
   "dependencies": {
     "@jupyter-widgets/base": "^2  || ^3 || ^4",
+    "@wwtelescope/research-app": "^0.3",
     "underscore": "^1"
   },
   "description": "AAS WorldWide Telescope from Python",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
   },
   "dependencies": {
     "@jupyter-widgets/base": "^2  || ^3 || ^4",
-    "@wwtelescope/research-app": "^0.3",
+    "@wwtelescope/research-app": "^0.4",
     "underscore": "^1"
   },
   "description": "AAS WorldWide Telescope from Python",

--- a/frontend/pywwt-export.js
+++ b/frontend/pywwt-export.js
@@ -6,6 +6,10 @@ var shell = require('shelljs');
 shell.cp('dist/bundle.js', '../pywwt/nbextension/static/index.js');
 shell.cp('dist/bundle.js.map', '../pywwt/nbextension/static/index.js.map');
 
+shell.rm('-rf', '../pywwt/web_static/research');
+shell.mkdir('-p', '../pywwt/web_static/research');
+shell.cp('-r', 'node_modules/@wwtelescope/research-app/dist/*', '../pywwt/web_static/research');
+
 shell.rm('-rf', '../pywwt/labextension');
 shell.mkdir('-p', '../pywwt/labextension');
 shell.cp('pywwt-*.tgz', '../pywwt/labextension/');

--- a/pywwt/core.py
+++ b/pywwt/core.py
@@ -52,6 +52,7 @@ class BaseWWTWidget(HasTraits):
     This class provides a common interface to modify settings and interact with
     the AAS WorldWide Telescope.
     """
+
     def __init__(self, **kwargs):
         super(BaseWWTWidget, self).__init__()
         self.observe(self._on_trait_change, type='change')
@@ -104,6 +105,8 @@ class BaseWWTWidget(HasTraits):
         """
         self._seqNum += 1
         return str(self._seqNum)
+
+    # Support methods that can/should be overridden by subclasses
 
     def _send_msg(self, **kwargs):
         # This method should be overridden and should send the message to WWT
@@ -165,22 +168,56 @@ class BaseWWTWidget(HasTraits):
         from .layers import ImageLayer
         return ImageLayer(self, **kwargs)
 
+    # Main attributes
+
+    current_mode = None
+    "The current rendering mode of the engine"
+
+    imagery = None
+    "Access to the engine's available imagesets"
+
+    @property
+    def instruments(self):
+        """
+        A list of instruments available for use in `add_fov`.
+        """
+        return self._instruments
+
+    layers = None
+    "Access to the active rendering layers"
+
+    solar_system = None
+    "Access to solar-system settings and data"
+
+    # Settings.
+    #
+    # TODO: implement the remaining ones that haven't been wired up yet.
+
     actual_planet_scale = Bool(False,
                                help='Whether to show planets to scale or as '
                                     'points with a fixed size '
                                     '(`bool`)').tag(wwt='actualPlanetScale', wwt_reset=True)
 
-    # TODO: need to add all settings as traits check the widget HTML for
-    # comments on settings that are disabled below
+    alt_az_grid = Bool(False, help='Whether to show an altitude-azimuth grid '
+                                   '(`bool`)').tag(wwt='showAltAzGrid', wwt_reset=True)
+
+    # alt_az_text = Bool(False,
+    #                    help='Whether to show labels for the altitude-azimuth grid\'s text '
+    #                         '(`bool`)').tag(wwt='showAltAzGridText', wwt_reset=True)
+
+    background = Unicode('Hydrogen Alpha Full Sky Map',
+                         help='The layer to show in the background (`str`)').tag(wwt=None, wwt_reset=True)
 
     constellation_boundary_color = Color('blue',
                                          help='The color of the constellation '
                                          'boundaries (`str` or '
                                          '`tuple`)').tag(wwt='constellationBoundryColor', wwt_reset=True)
+
     constellation_figure_color = Color('red',
                                        help='The color of the constellation '
                                             'figure (`str` or '
                                             '`tuple`)').tag(wwt='constellationFigureColor', wwt_reset=True)
+
     constellation_selection_color = Color('yellow',
                                           help='The color of the constellation '
                                                'selection (`str` or '
@@ -190,9 +227,11 @@ class BaseWWTWidget(HasTraits):
                                     help='Whether to show boundaries for the '
                                          'selected constellations '
                                          '(`bool`)').tag(wwt='showConstellationBoundries', wwt_reset=True)
+
     constellation_figures = Bool(False,
                                  help='Whether to show the constellations '
                                       '(`bool`)').tag(wwt='showConstellationFigures', wwt_reset=True)
+
     constellation_selection = Bool(False,
                                    help='Whether to only show boundaries for '
                                         'the selected constellation '
@@ -202,30 +241,127 @@ class BaseWWTWidget(HasTraits):
     #                               help='Whether to show pictures of the constellations\' '
     #                                    'mythological representations '
     #                                    '(`bool`)').tag(wwt='showConstellationPictures', wwt_reset=True)
+
     # constellation_labels = Bool(False,
     #                             help='Whether to show labelss for constellations '
     #                                  '(`bool`)').tag(wwt='showConstellationLabels', wwt_reset=True)
 
     crosshairs = Bool(False, help='Whether to show crosshairs at the center of '
                                   'the field (`bool`)').tag(wwt='showCrosshairs', wwt_reset=True)
+
     crosshairs_color = Color('white',
                              help='The color of the crosshairs '
                                   '(`str` or `tuple`)').tag(wwt='crosshairsColor', wwt_reset=True)
-    grid = Bool(False, help='Whether to show the equatorial grid '
-                            '(`bool`)').tag(wwt='showGrid', wwt_reset=True)
+
     ecliptic = Bool(False, help='Whether to show the path of the ecliptic '
                                 '(`bool`)').tag(wwt='showEcliptic', wwt_reset=True)
+
     ecliptic_grid = Bool(False, help='Whether to show a grid relative to the '
                                      'ecliptic plane (`bool`)').tag(wwt='showEclipticGrid', wwt_reset=True)
 
-    # TODO: need to add more methods here.
+    foreground = Unicode('Digitized Sky Survey (Color)',
+                         help='The layer to show in the foreground (`str`)').tag(wwt=None, wwt_reset=True)
 
-    def clear_annotations(self):
-        """
-        Clears all annotations from the current view.
-        """
-        self._annotation_set.clear()
-        return self._send_msg(event='clear_annotations')
+    foreground_opacity = Float(0.8, help='The opacity of the foreground layer '
+                                         '(`float`)').tag(wwt=None, wwt_reset=True)
+
+    galactic_mode = Bool(False,
+                         help='Whether the galactic plane should be horizontal '
+                              'in the viewer (`bool`)').tag(wwt='galacticMode', wwt_reset=True)
+
+    galactic_grid = Bool(False, help='Whether to show a grid relative to the '
+                                     'galactic plane (`bool`)').tag(wwt='showGalacticGrid', wwt_reset=True)
+
+    # galactic_text = Bool(False,
+    #                      help='Whether to show labels for the galactic grid\'s text '
+    #                           '(`bool`)').tag(wwt='showGalacticGridText', wwt_reset=True)
+
+    grid = Bool(False, help='Whether to show the equatorial grid '
+                            '(`bool`)').tag(wwt='showGrid', wwt_reset=True)
+
+    local_horizon_mode = Bool(False, help='Whether the view should be that of '
+                                          'a local latitude, longitude, and '
+                                          'altitude (`bool`)').tag(wwt='localHorizonMode', wwt_reset=True)
+
+    location_altitude = AstropyQuantity(0 * u.m,
+                                        help='The altitude of the viewing '
+                                             'location in local horizon mode '
+                                             '(:class:`~astropy.units.Quantity`)').tag(wwt='locationAltitude', wwt_reset=True)
+
+    location_latitude = AstropyQuantity(47.633 * u.deg,
+                                        help='The latitude of the viewing '
+                                             'location in local horizon mode '
+                                             '(:class:`~astropy.units.Quantity`)').tag(wwt='locationLat', wwt_reset=True)
+
+    location_longitude = AstropyQuantity(122.133333 * u.deg,
+                                         help='The longitude of the viewing '
+                                              'location in local horizon mode '
+                                              '(:class:`~astropy.units.Quantity`)').tag(wwt='locationLng', wwt_reset=True)
+
+    # Validators / observers for the settings above that need custom support.
+
+    @observe('background')
+    def _on_background_change(self, changed):
+        self._send_msg(event='set_background_by_name', name=changed['new'])
+        # Changing a layer resets the opacity, so we re-trigger the opacity setting
+        self._send_msg(event='set_foreground_opacity',
+                       value=self.foreground_opacity * 100)
+
+    @validate('background')
+    def _validate_background(self, proposal):
+        if proposal['value'] in self.available_layers:
+            return proposal['value']
+        else:
+            raise TraitError('background is not one of the available layers')
+
+    @observe('foreground')
+    def _on_foreground_change(self, changed):
+        self._send_msg(event='set_foreground_by_name', name=changed['new'])
+        # Changing a layer resets the opacity, so we re-trigger the opacity setting
+        self._send_msg(event='set_foreground_opacity',
+                       value=self.foreground_opacity * 100)
+
+    @validate('foreground')
+    def _validate_foreground(self, proposal):
+        if proposal['value'] in self.available_layers:
+            return proposal['value']
+        else:
+            raise TraitError('foreground is not one of the available layers')
+
+    @observe('foreground_opacity')
+    def _on_foreground_opacity_change(self, changed):
+        self._send_msg(event='set_foreground_opacity',
+                       value=changed['new'] * 100)
+
+    @validate('foreground_opacity')
+    def _validate_foreground_opacity(self, proposal):
+        if 0 <= proposal['value'] <= 1:
+            return proposal['value']
+        else:
+            raise TraitError('foreground_opacity should be between 0 and 1')
+
+    @validate('location_altitude')
+    def _validate_altitude(self, proposal):
+        if proposal['value'].unit.physical_type == 'length':
+            return proposal['value'].to(u.meter)
+        else:
+            raise TraitError('location_altitude not in units of length')
+
+    @validate('location_latitude')
+    def _validate_latitude(self, proposal):
+        if proposal['value'].unit.physical_type == 'angle':
+            return proposal['value'].to(u.degree)
+        else:
+            raise TraitError('location_latitude not in angle units')
+
+    @validate('location_longitude')
+    def _validate_longitude(self, proposal):
+        if proposal['value'].unit.physical_type == 'angle':
+            return proposal['value'].to(u.degree)
+        else:
+            raise TraitError('location_longitude not in angle units')
+
+    # Basic view controls
 
     def get_center(self):
         """
@@ -240,72 +376,6 @@ class BaseWWTWidget(HasTraits):
         Return the view's current field of view in degrees.
         """
         return self._get_view_data('fov') * u.deg
-
-    def load_tour(self, url):
-        """
-        Load and begin playing a tour based on the URL to a .wtt file from
-        the WorldWideTelescope website.
-
-        Parameters
-        ----------
-        url : `str`
-            The URL of the chosen tour -- must be a .wtt file.
-        """
-        # throw error if url doesn't end in .wtt
-        if url[-4:] == '.wtt':
-            self._send_msg(event='load_tour', url=url)
-        else:
-            raise ValueError('url must end in \'.wwt\'')
-
-    def pause_tour(self):
-        """
-        Pause a loaded tour.
-        """
-        self._send_msg(event='pause_tour')
-
-    def resume_tour(self):
-        """
-        Resume a paused tour.
-        """
-        self._send_msg(event='resume_tour')
-
-    def pause_time(self):
-        """
-        Pause the progression of time in the viewer.
-        """
-        self._send_msg(event='pause_time')
-
-    def play_time(self, rate=1):
-        """
-        Resume the progression of time in the viewer.
-
-        Parameters
-        ----------
-        rate : int or float
-            The rate at which time passes (1 meaning real-time)
-        """
-        self._send_msg(event='resume_time', rate=rate)
-
-    def get_current_time(self):
-        """
-        Return the viewer's current time as an `~astropy.time.Time` object.
-        """
-        return Time(self._get_view_data('datetime'), format='isot')
-
-    def set_current_time(self, dt=None):
-        """
-        Set the viewer time to match the real-world time.
-
-        Parameters
-        ----------
-        dt : `~datetime.datetime` or `~astropy.time.Time`
-            The current time, either as a `datetime.datetime` object or an
-            astropy :class:`astropy.time.Time` object. If not specified, this
-            uses the current time
-        """
-        # Ensure the object received is a datetime or Time; convert it to UTC
-        utc_tm = ensure_utc(dt, str_allowed=False)
-        self._send_msg(event='set_datetime', isot=utc_tm)
 
     def center_on_coordinates(self, coord, fov=60 * u.deg, instant=True):
         """
@@ -329,57 +399,6 @@ class BaseWWTWidget(HasTraits):
                        dec=coord_icrs.dec.deg,
                        fov=fov.to(u.deg).value,
                        instant=instant)
-
-    galactic_mode = Bool(False,
-                         help='Whether the galactic plane should be horizontal '
-                              'in the viewer (`bool`)').tag(wwt='galacticMode', wwt_reset=True)
-    galactic_grid = Bool(False, help='Whether to show a grid relative to the '
-                                     'galactic plane (`bool`)').tag(wwt='showGalacticGrid', wwt_reset=True)
-    # galactic_text = Bool(False,
-    #                      help='Whether to show labels for the galactic grid\'s text '
-    #                           '(`bool`)').tag(wwt='showGalacticGridText', wwt_reset=True)
-    alt_az_grid = Bool(False, help='Whether to show an altitude-azimuth grid '
-                                   '(`bool`)').tag(wwt='showAltAzGrid', wwt_reset=True)
-    # alt_az_text = Bool(False,
-    #                    help='Whether to show labels for the altitude-azimuth grid\'s text '
-    #                         '(`bool`)').tag(wwt='showAltAzGridText', wwt_reset=True)
-
-    local_horizon_mode = Bool(False, help='Whether the view should be that of '
-                                          'a local latitude, longitude, and '
-                                          'altitude (`bool`)').tag(wwt='localHorizonMode', wwt_reset=True)
-    location_altitude = AstropyQuantity(0 * u.m,
-                                        help='The altitude of the viewing '
-                                             'location in local horizon mode '
-                                             '(:class:`~astropy.units.Quantity`)').tag(wwt='locationAltitude', wwt_reset=True)
-    location_latitude = AstropyQuantity(47.633 * u.deg,
-                                        help='The latitude of the viewing '
-                                             'location in local horizon mode '
-                                             '(:class:`~astropy.units.Quantity`)').tag(wwt='locationLat', wwt_reset=True)
-    location_longitude = AstropyQuantity(122.133333 * u.deg,
-                                         help='The longitude of the viewing '
-                                              'location in local horizon mode '
-                                              '(:class:`~astropy.units.Quantity`)').tag(wwt='locationLng', wwt_reset=True)
-
-    @validate('location_altitude')
-    def _validate_altitude(self, proposal):
-        if proposal['value'].unit.physical_type == 'length':
-            return proposal['value'].to(u.meter)
-        else:
-            raise TraitError('location_altitude not in units of length')
-
-    @validate('location_latitude')
-    def _validate_latitude(self, proposal):
-        if proposal['value'].unit.physical_type == 'angle':
-            return proposal['value'].to(u.degree)
-        else:
-            raise TraitError('location_latitude not in angle units')
-
-    @validate('location_longitude')
-    def _validate_longitude(self, proposal):
-        if proposal['value'].unit.physical_type == 'angle':
-            return proposal['value'].to(u.degree)
-        else:
-            raise TraitError('location_longitude not in angle units')
 
     def set_view(self, mode):
         """
@@ -454,6 +473,66 @@ class BaseWWTWidget(HasTraits):
         """
         return sorted(VIEW_MODES_2D + VIEW_MODES_3D)
 
+    def reset(self):
+        """
+        Reset WWT to initial state.
+        """
+
+        # Remove any existing layers (not using a for loop since we're removing elements)
+        while len(self.layers) > 0:
+            self.layers[0].remove()
+
+        # Reset coordinates to initial view
+        gc = SkyCoord(0, 0, unit=('deg', 'deg'), frame='icrs')
+        self.center_on_coordinates(gc, 60 * u.deg)
+
+        # Reset only traits with the wwt_reset tag
+        for trait_name, trait in self.traits().items():
+            if trait.metadata.get('wwt_reset'):
+                setattr(self, trait_name, trait.default_value)
+
+    # Clock controls
+
+    def pause_time(self):
+        """
+        Pause the progression of time in the viewer.
+        """
+        self._send_msg(event='pause_time')
+
+    def play_time(self, rate=1):
+        """
+        Resume the progression of time in the viewer.
+
+        Parameters
+        ----------
+        rate : int or float
+            The rate at which time passes (1 meaning real-time)
+        """
+        self._send_msg(event='resume_time', rate=rate)
+
+    def get_current_time(self):
+        """
+        Return the viewer's current time as an `~astropy.time.Time` object.
+        """
+        return Time(self._get_view_data('datetime'), format='isot')
+
+    def set_current_time(self, dt=None):
+        """
+        Set the viewer time to match the real-world time.
+
+        Parameters
+        ----------
+        dt : `~datetime.datetime` or `~astropy.time.Time`
+            The current time, either as a `datetime.datetime` object or an
+            astropy :class:`astropy.time.Time` object. If not specified, this
+            uses the current time
+        """
+        # Ensure the object received is a datetime or Time; convert it to UTC
+        utc_tm = ensure_utc(dt, str_allowed=False)
+        self._send_msg(event='set_datetime', isot=utc_tm)
+
+    # Data loading
+
     def load_image_collection(self, url):
         """
         Load a collection of layers for possible use in the viewer.
@@ -477,55 +556,14 @@ class BaseWWTWidget(HasTraits):
         """
         return sorted(self._available_layers)
 
-    foreground = Unicode('Digitized Sky Survey (Color)',
-                         help='The layer to show in the foreground (`str`)').tag(wwt=None, wwt_reset=True)
+    # Annotations
 
-    @observe('foreground')
-    def _on_foreground_change(self, changed):
-        self._send_msg(event='set_foreground_by_name', name=changed['new'])
-        # Changing a layer resets the opacity, so we re-trigger the opacity setting
-        self._send_msg(event='set_foreground_opacity',
-                       value=self.foreground_opacity * 100)
-
-    @validate('foreground')
-    def _validate_foreground(self, proposal):
-        if proposal['value'] in self.available_layers:
-            return proposal['value']
-        else:
-            raise TraitError('foreground is not one of the available layers')
-
-    background = Unicode('Hydrogen Alpha Full Sky Map',
-                         help='The layer to show in the background (`str`)').tag(wwt=None, wwt_reset=True)
-
-    @observe('background')
-    def _on_background_change(self, changed):
-        self._send_msg(event='set_background_by_name', name=changed['new'])
-        # Changing a layer resets the opacity, so we re-trigger the opacity setting
-        self._send_msg(event='set_foreground_opacity',
-                       value=self.foreground_opacity * 100)
-
-    @validate('background')
-    def _validate_background(self, proposal):
-        if proposal['value'] in self.available_layers:
-            return proposal['value']
-        else:
-            raise TraitError('background is not one of the available layers')
-
-    foreground_opacity = Float(0.8, help='The opacity of the foreground layer '
-                                         '(`float`)').tag(wwt=None,
-                                                          wwt_reset=True)
-
-    @observe('foreground_opacity')
-    def _on_foreground_opacity_change(self, changed):
-        self._send_msg(event='set_foreground_opacity',
-                       value=changed['new'] * 100)
-
-    @validate('foreground_opacity')
-    def _validate_foreground_opacity(self, proposal):
-        if 0 <= proposal['value'] <= 1:
-            return proposal['value']
-        else:
-            raise TraitError('foreground_opacity should be between 0 and 1')
+    def clear_annotations(self):
+        """
+        Clears all annotations from the current view.
+        """
+        self._annotation_set.clear()
+        return self._send_msg(event='clear_annotations')
 
     def add_circle(self, center=None, **kwargs):
         """
@@ -586,12 +624,54 @@ class BaseWWTWidget(HasTraits):
             line.add_point(points)
         return line
 
-    @property
-    def instruments(self):
+    def add_collection(self, points, **kwargs):
         """
-        A list of instruments available for use in `add_fov`.
+        Add a CircleCollection to the current view.
+
+        Parameters
+        ----------
+        points : `~astropy.units.Quantity`
+            The desired points that will serve as the centers of the
+            circles that make up the collection. Requires at least two
+            sets of coordinates for initialization.
+        kwargs
+            Optional arguments that allow corresponding Circle or
+            Annotation attributes to be set upon shape initialization.
         """
-        return self._instruments
+        collection = CircleCollection(self, points, **kwargs)
+        return collection
+
+    # Tours
+
+    def load_tour(self, url):
+        """
+        Load and begin playing a tour based on the URL to a .wtt file from
+        the WorldWideTelescope website.
+
+        Parameters
+        ----------
+        url : `str`
+            The URL of the chosen tour -- must be a .wtt file.
+        """
+        # throw error if url doesn't end in .wtt
+        if url[-4:] == '.wtt':
+            self._send_msg(event='load_tour', url=url)
+        else:
+            raise ValueError('url must end in \'.wwt\'')
+
+    def pause_tour(self):
+        """
+        Pause a loaded tour.
+        """
+        self._send_msg(event='pause_tour')
+
+    def resume_tour(self):
+        """
+        Resume a paused tour.
+        """
+        self._send_msg(event='resume_tour')
+
+    # Instrumental FOV support (built on the annotation support)
 
     def add_fov(self, telescope, center=None, rotate=0*u.rad, **kwargs):
         """
@@ -615,40 +695,7 @@ class BaseWWTWidget(HasTraits):
         """
         return FieldOfView(self, telescope, center, rotate, **kwargs)
 
-    def add_collection(self, points, **kwargs):
-        """
-        Add a CircleCollection to the current view.
-
-        Parameters
-        ----------
-        points : `~astropy.units.Quantity`
-            The desired points that will serve as the centers of the
-            circles that make up the collection. Requires at least two
-            sets of coordinates for initialization.
-        kwargs
-            Optional arguments that allow corresponding Circle or
-            Annotation attributes to be set upon shape initialization.
-        """
-        collection = CircleCollection(self, points, **kwargs)
-        return collection
-
-    def reset(self):
-        """
-        Reset WWT to initial state.
-        """
-
-        # Remove any existing layers (not using a for loop since we're removing elements)
-        while len(self.layers) > 0:
-            self.layers[0].remove()
-
-        # Reset coordinates to initial view
-        gc = SkyCoord(0, 0, unit=('deg', 'deg'), frame='icrs')
-        self.center_on_coordinates(gc, 60 * u.deg)
-
-        # Reset only traits with the wwt_reset tag
-        for trait_name, trait in self.traits().items():
-            if trait.metadata.get('wwt_reset'):
-                setattr(self, trait_name, trait.default_value)
+    # HTML (interactive figure) export
 
     def save_as_html_bundle(self, dest, title=None, max_width=None, max_height=None):
         """

--- a/pywwt/core.py
+++ b/pywwt/core.py
@@ -1,37 +1,61 @@
-import numpy as np
-import os
-from traitlets import HasTraits, observe, validate, TraitError
-from astropy import units as u
-from astropy.time import Time
-from astropy.coordinates import SkyCoord
+# Copyright 2018-2021 the .NET Foundation
+# Licensed under the BSD license
 
-# We import the trait classes from .traits since we do various customizations
-from .traits import Color, Bool, Float, Unicode, AstropyQuantity
-
-from .annotation import Circle, Polygon, Line, FieldOfView, CircleCollection
-from .imagery import get_imagery_layers, ImageryLayers
-from .solar_system import SolarSystem
-from .layers import LayerManager
-from .instruments import Instruments
-from .utils import ensure_utc
+"""
+The core WWT widget implementation.
+"""
 
 import json
+import os
 import shutil
 import tempfile
 
-DEFAULT_SURVEYS_URL = 'https://worldwidetelescope.github.io/pywwt/surveys.xml'
+from astropy import units as u
+from astropy.time import Time
+from astropy.coordinates import SkyCoord
+import numpy as np
+from traitlets import HasTraits, observe, validate, TraitError
 
-VIEW_MODES_2D = ['sky', 'sun', 'mercury', 'venus', 'earth', 'moon', 'mars',
-                 'jupiter', 'callisto', 'europa', 'ganymede', 'io',
-                 'saturn', 'uranus', 'neptune', 'pluto',
-                 'panorama']
-VIEW_MODES_3D = ['solar system', 'milky way', 'universe']
-
+from .annotation import Circle, Polygon, Line, FieldOfView, CircleCollection
+from .imagery import get_imagery_layers, ImageryLayers
+from .instruments import Instruments
+from .layers import LayerManager
+from .solar_system import SolarSystem
+from .traits import Color, Bool, Float, Unicode, AstropyQuantity
+from .utils import ensure_utc
 
 __all__ = [
     'AppBasedWWTWidget',
     'BaseWWTWidget',
     'DataPublishingNotAvailableError',
+]
+
+DEFAULT_SURVEYS_URL = 'https://worldwidetelescope.github.io/pywwt/surveys.xml'
+
+VIEW_MODES_2D = [
+    'sky',
+    'sun',
+    'mercury',
+    'venus',
+    'earth',
+    'moon',
+    'mars',
+    'jupiter',
+    'callisto',
+    'europa',
+    'ganymede',
+    'io',
+    'saturn',
+    'uranus',
+    'neptune',
+    'pluto',
+    'panorama',
+]
+
+VIEW_MODES_3D = [
+    'solar system',
+    'milky way',
+    'universe',
 ]
 
 

--- a/pywwt/core.py
+++ b/pywwt/core.py
@@ -542,14 +542,22 @@ class BaseWWTWidget(HasTraits):
 
     def set_current_time(self, dt=None):
         """
-        Set the viewer time to match the real-world time.
+        Set WWT's internal clock.
 
         Parameters
         ----------
         dt : `~datetime.datetime` or `~astropy.time.Time`
-            The current time, either as a `datetime.datetime` object or an
+            A time, either as a `datetime.datetime` object or an
             astropy :class:`astropy.time.Time` object. If not specified, this
-            uses the current time
+            uses the current time.
+
+        Notes
+        -----
+        If you call this function and then immediately call
+        :meth:`get_current_time`, the results will not necessarily agree. This
+        is because this function has to send a command to WWT to tell it to
+        update its internal clock, and in some environments this operation is
+        not instantaneous.
         """
         # Ensure the object received is a datetime or Time; convert it to UTC
         utc_tm = ensure_utc(dt, str_allowed=False)
@@ -565,6 +573,15 @@ class BaseWWTWidget(HasTraits):
         ----------
         url : `str`
             The URL of the desired image collection.
+
+        Notes
+        -----
+        The request to load the image collection must be relayed to the WWT
+        JavaScript code, which will then issue a web request and process the
+        response that it gets. Therefore, you can't rely on this function to
+        take immediate effect; to use an image in a collection that you've
+        loaded, you'll need to pause and give WWT time to receive and process
+        your request.
         """
         self._available_layers.update(get_imagery_layers(url))
         self._send_msg(

--- a/pywwt/jupyter_server.py
+++ b/pywwt/jupyter_server.py
@@ -25,7 +25,10 @@ from tornado import web
 from notebook.utils import url_path_join
 from notebook.base.handlers import IPythonHandler
 
-__all__ = ['load_jupyter_server_extension']
+__all__ = [
+    'load_jupyter_server_extension',
+    'serve_file',
+]
 
 
 STATIC_DIR = os.path.join(os.path.dirname(__file__), 'web_static')
@@ -64,7 +67,10 @@ class WWTFileHandler(IPythonHandler):
                 raise web.HTTPError(404)
 
         # Do our best to set an appropriate Content-Type.
-        self.set_header('Content-Type', mimetypes.guess_type(filename)[0])
+        content_type = mimetypes.guess_type(filename)[0]
+        if content_type is None:
+            content_type = 'application/binary'
+        self.set_header('Content-Type', content_type)
 
         # Add wide-open CORS headers to allow external WWT apps to access data.
         self.set_header('Access-Control-Allow-Origin', '*')

--- a/pywwt/solar_system.py
+++ b/pywwt/solar_system.py
@@ -63,7 +63,7 @@ class SolarSystem(HasTraits):
     @validate('scale')
     def _validate_scale(self, proposal):
         if 1 <= proposal['value'] <= 100:
-            return str(proposal['value'])
+            return proposal['value']
         else:
             raise ValueError('scale takes integers from 1-100')
 

--- a/pywwt/tests/test_serialization.py
+++ b/pywwt/tests/test_serialization.py
@@ -172,7 +172,7 @@ def test_3d_serialization():
                             'solarSystemMinorOrbits': False,
                             'solarSystemOrbits': True,
                             'solarSystemPlanets': False,
-                            'solarSystemScale': '8',  # The validation method casts the int to a string
+                            'solarSystemScale': 8,
                             'solarSystemStars': True}
 
     init_state = widget.quick_serialize()


### PR DESCRIPTION
### Overview

<!-- briefly describe the purpose of the pull request here;
    mention any closed issues; see https://help.github.com/articles/closing-issues-using-keywords/ -->

Firstly, here we start bundling the research app with the Jupyter extension. While the native JupyterLab extension loads the app directly from its hosted WWT instance, there are valid cases to use a bundled version. In particular, I've seen at least one example (SciServer) where a cross-origin app isn't allowed to access data from a Jupyter server.

Secondly, we port the Jupyter widget implementation (i.e., ipywidgets) to use the app instead of the hand-coded HTML implementation. This turns out to be somewhat involved since the app needed some upgrading to handle the ipywidgets setup, which can involve both multiple clients (multiple widgets) and multiple apps (multiple views per widget).

### Checklist

- [x] Changed code has some test coverage (or justify why not)
- [ ] Changes in functionality documented (or justify why not)
