### PR TITLE
Restore the wwt_ready Qt signal

### DIFF
--- a/frontend/pywwt-export.js
+++ b/frontend/pywwt-export.js
@@ -3,6 +3,7 @@
 
 var shell = require('shelljs');
 
+shell.mkdir('-p', '../pywwt/nbextension/static');
 shell.cp('dist/bundle.js', '../pywwt/nbextension/static/index.js');
 shell.cp('dist/bundle.js.map', '../pywwt/nbextension/static/index.js.map');
 


### PR DESCRIPTION
<!-- Thank you for your pull request! Please summarize it with the following form. -->

### Overview

<!-- briefly describe the purpose of the pull request here;
    mention any closed issues; see https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #306.

### Checklist

(This should add test coverage but I am being a bad lazy person :-()