### PR TITLE
Allow for WTML parsing when ThumbnailURL is absent

### DIFF
--- a/pywwt/imagery.py
+++ b/pywwt/imagery.py
@@ -30,9 +30,9 @@ def get_imagery_layers(url):
 
     for survey in t.iter('ImageSet'):
         name = survey.attrib['Name']
-        thumbnail_url = survey.find('ThumbnailUrl').text
-        if not thumbnail_url:
-            thumbnail_url = None
+        thumbnail_url = survey.find('ThumbnailUrl')
+        if thumbnail_url is not None:
+            thumbnail_url = getattr(thumbnail_url, 'text', None) or None
         available_layers[name] = {'thumbnail': thumbnail_url}
 
     return available_layers


### PR DESCRIPTION
### Overview

While attempting to load [this WTML collection](https://wwtambassadors.org/files/wwtambassadors/files/buacgalaxyhistoryuniverse.wtml), I noticed that `pywwt` is currently unable to parse a collection where at least one entry has a missing `ThumbnailUrl` entry.

If `ThumbnailUrl` is not present, then `survey.find('ThumbnailUrl')` is `None`, and so `survey.find('ThumbnailUrl').text` yields an `AttributeError`. This PR fixes that issue by first checking whether or not the call to `find` returned `None`.

The `or None` at the end of line 35 is to retain the previous behavior of an empty string (which is falsy) being converted to `None`.

FWIW, this file loads correctly in the web client (where the two entries without thumbnail urls, UGC 2369 and 4C 73.08, are given a default thumbnail).

### Checklist


- [ ] Changed code has some test coverage (or justify why not)
- [ ] Changes in functionality documented (or justify why not)
