### PR TITLE
More add layer options

### DIFF
--- a/pywwt/layers.py
+++ b/pywwt/layers.py
@@ -238,7 +238,15 @@ class LayerManager(object):
         self._layers = []
         self._parent = parent
 
-    def add_image_layer(self, image=None, hdu_index=None, verbose=True, force_hipsgen=False, force_tan=False, **kwargs):
+    def add_image_layer(
+        self,
+        image=None,
+        hdu_index=None,
+        verbose=True,
+        force_hipsgen=False,
+        force_tan=False,
+        **kwargs
+    ):
         """
         Add an image layer to the current view. This method can display any
         image data or FITS or list of FITS from the local environment. In case
@@ -287,25 +295,43 @@ class LayerManager(object):
         layer : :class:`~pywwt.layers.ImageLayer` or a subclass thereof
         """
 
-        if (isinstance(image, astropy.io.fits.ImageHDU) or
-                isinstance(image, astropy.io.fits.PrimaryHDU) or
-                isinstance(image, astropy.io.fits.HDUList)):
+        if (
+            isinstance(image, astropy.io.fits.ImageHDU)
+            or isinstance(image, astropy.io.fits.PrimaryHDU)
+            or isinstance(image, astropy.io.fits.HDUList)
+        ):
             unused_file_name = self._get_unused_fits_name()
             image.writeto(unused_file_name)
             image = unused_file_name
         if isinstance(image, str):
             image = [image]
         if isinstance(image, list):
-            if force_hipsgen or force_tan or len(image) > 1 or Path(image[0]).stat().st_size > 20e6:  # 20 MB
+            if (
+                force_hipsgen
+                or force_tan
+                or len(image) > 1
+                or Path(image[0]).stat().st_size > 20e6
+            ):  # 20 MB
                 nest_asyncio.apply()
                 loop = asyncio.get_event_loop()
-                return loop.run_until_complete(self._tile_and_serve(fits_list=image, hdu_index=hdu_index,
-                                                                    cli_progress=verbose, force_hipsgen=force_hipsgen,
-                                                                    force_tan=force_tan, **kwargs))
+                return loop.run_until_complete(
+                    self._tile_and_serve(
+                        fits_list=image,
+                        hdu_index=hdu_index,
+                        cli_progress=verbose,
+                        force_hipsgen=force_hipsgen,
+                        force_tan=force_tan,
+                        **kwargs
+                    )
+                )
             else:
-                return self._create_and_add_image_layer(image=image[0], hdu_index=hdu_index, **kwargs)
+                return self._create_and_add_image_layer(
+                    image=image[0], hdu_index=hdu_index, **kwargs
+                )
 
-        return self._create_and_add_image_layer(image=image, hdu_index=hdu_index, **kwargs)
+        return self._create_and_add_image_layer(
+            image=image, hdu_index=hdu_index, **kwargs
+        )
 
     def _create_and_add_image_layer(self, image, **kwargs):
         kwargs = self._remove_toasty_keywords(**kwargs)
@@ -335,9 +361,9 @@ class LayerManager(object):
 
     # TODO this is not future proof
     def _remove_toasty_keywords(self, **kwargs):
-        kwargs.pop('blankval', None)
-        kwargs.pop('override', None)
-        kwargs.pop('out_dir', None)
+        kwargs.pop("blankval", None)
+        kwargs.pop("override", None)
+        kwargs.pop("out_dir", None)
         return kwargs
 
     def _get_unused_fits_name(self):
@@ -346,17 +372,27 @@ class LayerManager(object):
             file_index += 1
         return "hdu_fits_{}".format(file_index)
 
-    async def _tile_and_serve(self, fits_list, hdu_index=None, cli_progress=True, force_hipsgen=False,
-                              force_tan=False, **kwargs):
-        name, builder = toasty.tile_fits(fits_list, hdu_index=hdu_index, cli_progress=cli_progress,
-                                         force_hipsgen=force_hipsgen, force_tan=force_tan, **kwargs)
+    async def _tile_and_serve(
+        self,
+        fits_list,
+        hdu_index=None,
+        cli_progress=True,
+        force_hipsgen=False,
+        force_tan=False,
+        **kwargs
+    ):
+        name, builder = toasty.tile_fits(
+            fits_list,
+            hdu_index=hdu_index,
+            cli_progress=cli_progress,
+            force_hipsgen=force_hipsgen,
+            force_tan=force_tan,
+            **kwargs
+        )
         kwargs = self._remove_toasty_keywords(**kwargs)
         url = self._parent._serve_tree(path=name)
 
-        self._parent.load_image_collection(
-            url=url + 'index.wtml',
-            remote_only=True
-        )
+        self._parent.load_image_collection(url=url + "index.wtml", remote_only=True)
         return self.add_preloaded_image_layer(url + builder.imgset.url, **kwargs)
 
     def add_table_layer(self, table=None, frame="Sky", **kwargs):
@@ -530,7 +566,7 @@ class TableLayer(HasTraits):
     coord_type = Unicode(
         "spherical",
         help="Whether to give the coordinates "
-             "in spherical or rectangular coordinates",
+        "in spherical or rectangular coordinates",
     ).tag(wwt="coordinatesType")
 
     # Attributes for spherical coordinates
@@ -577,15 +613,15 @@ class TableLayer(HasTraits):
     size_vmin = Float(
         None,
         help="The minimum point size. "
-             "Found automagically once size_att is set "
-             "(`float`)",
+        "Found automagically once size_att is set "
+        "(`float`)",
         allow_none=True,
     ).tag(wwt=None)
     size_vmax = Float(
         None,
         help="The maximum point size. "
-             "Found automagically once size_att is set "
-             "(`float`)",
+        "Found automagically once size_att is set "
+        "(`float`)",
         allow_none=True,
     ).tag(wwt=None)
 
@@ -595,13 +631,13 @@ class TableLayer(HasTraits):
     cmap_vmin = Float(
         None,
         help="The minimum level of the colormap. Found "
-             "automagically once cmap_att is set (`float`)",
+        "automagically once cmap_att is set (`float`)",
         allow_none=True,
     ).tag(wwt=None)
     cmap_vmax = Float(
         None,
         help="The maximum level of the colormap. Found "
-             "automagically once cmap_att is set (`float`)",
+        "automagically once cmap_att is set (`float`)",
         allow_none=True,
     ).tag(wwt=None)
     cmap = Any(
@@ -630,8 +666,8 @@ class TableLayer(HasTraits):
     far_side_visible = Bool(
         False,
         help="Whether markers on the far side "
-             "of a 3D object are visible "
-             "(`bool`)",
+        "of a 3D object are visible "
+        "(`bool`)",
     ).tag(wwt="showFarSide")
 
     # NOTE: we deliberately don't link time_att to startDateColumn here
@@ -644,9 +680,9 @@ class TableLayer(HasTraits):
     time_decay = AstropyQuantity(
         16 * u.day,
         help="How long a time series "
-             "point takes to fade away after appearing (0 "
-             "if never) "
-             "(:class:`~astropy.units.Quantity`)",
+        "point takes to fade away after appearing (0 "
+        "if never) "
+        "(:class:`~astropy.units.Quantity`)",
     ).tag(wwt="decay")
 
     # TODO: support:
@@ -658,13 +694,13 @@ class TableLayer(HasTraits):
     # zAxisReverse
 
     def __init__(
-            self,
-            parent=None,
-            table=None,
-            frame=None,
-            table_from_wwt_engine=False,
-            id=None,
-            **kwargs
+        self,
+        parent=None,
+        table=None,
+        frame=None,
+        table_from_wwt_engine=False,
+        id=None,
+        **kwargs
     ):
         self.table = table
         self.notify_changes = True
@@ -799,7 +835,7 @@ class TableLayer(HasTraits):
         col = self._get_table()[proposal["value"]]
 
         if all(isinstance(t, datetime) for t in col) or all(
-                isinstance(t, Time) for t in col
+            isinstance(t, Time) for t in col
         ):
             return proposal["value"]
 
@@ -1127,9 +1163,9 @@ class TableLayer(HasTraits):
     def _on_time_att_change(self, *value):
 
         if (
-                not self.notify_changes
-                or len(self.time_att) == 0
-                or self.time_series is False
+            not self.notify_changes
+            or len(self.time_att) == 0
+            or self.time_series is False
         ):
             self.parent._send_msg(
                 event="table_layer_set", id=self.id, setting="startDateColumn", value=-1
@@ -1281,7 +1317,7 @@ class TableLayer(HasTraits):
         file_path = path.join(dir, "{0}.csv".format(self.id))
         table_str = csv_table_win_newline(self.table)
         with open(
-                file_path, "wb"
+            file_path, "wb"
         ) as file:  # binary mode to preserve windows line endings
             file.write(table_str.encode("ascii", errors="replace"))
 
@@ -1449,7 +1485,7 @@ class ImageLayer(HasTraits):
             # projection, double values) and write out to a temporary file.
             self._sanitized_image = tempfile.mktemp()
             sanitize_image(image, self._sanitized_image, **kwargs)
-            kwargs.pop('hdu_index', None)
+            kwargs.pop("hdu_index", None)
 
             # The first thing we need to do is make sure the image is being served.
             # For now we assume that image is a filename, but we could do more

--- a/pywwt/layers.py
+++ b/pywwt/layers.py
@@ -337,6 +337,7 @@ class LayerManager(object):
     def _remove_toasty_keywords(self, **kwargs):
         kwargs.pop('blankval', None)
         kwargs.pop('override', None)
+        kwargs.pop('out_dir', None)
         return kwargs
 
     def _get_unused_fits_name(self):

--- a/pywwt/layers.py
+++ b/pywwt/layers.py
@@ -380,14 +380,18 @@ class LayerManager(object):
         force_tan=False,
         **kwargs
     ):
-        name, builder = toasty.tile_fits(
-            fits_list,
-            hdu_index=hdu_index,
-            cli_progress=cli_progress,
-            force_hipsgen=force_hipsgen,
-            force_tan=force_tan,
-            **kwargs
-        )
+        with warnings.catch_warnings():
+            # Avoid annoying AstroPy FITS-fixed warnings
+            warnings.simplefilter("ignore")
+            name, builder = toasty.tile_fits(
+                fits_list,
+                hdu_index=hdu_index,
+                cli_progress=cli_progress,
+                force_hipsgen=force_hipsgen,
+                force_tan=force_tan,
+                **kwargs
+            )
+
         kwargs = self._remove_toasty_keywords(**kwargs)
         url = self._parent._serve_tree(path=name)
 

--- a/pywwt/layers.py
+++ b/pywwt/layers.py
@@ -303,9 +303,9 @@ class LayerManager(object):
                                                                     cli_progress=verbose, force_hipsgen=force_hipsgen,
                                                                     force_tan=force_tan, **kwargs))
             else:
-                return self._create_and_add_image_layer(image=image[0], **kwargs)
+                return self._create_and_add_image_layer(image=image[0], hdu_index=hdu_index, **kwargs)
 
-        return self._create_and_add_image_layer(image=image, **kwargs)
+        return self._create_and_add_image_layer(image=image, hdu_index=hdu_index, **kwargs)
 
     def _create_and_add_image_layer(self, image, **kwargs):
         kwargs = self._remove_toasty_keywords(**kwargs)
@@ -1448,6 +1448,7 @@ class ImageLayer(HasTraits):
             # projection, double values) and write out to a temporary file.
             self._sanitized_image = tempfile.mktemp()
             sanitize_image(image, self._sanitized_image, **kwargs)
+            kwargs.pop('hdu_index', None)
 
             # The first thing we need to do is make sure the image is being served.
             # For now we assume that image is a filename, but we could do more

--- a/pywwt/layers.py
+++ b/pywwt/layers.py
@@ -263,7 +263,7 @@ class LayerManager(object):
             a Numpy array and ``wcs`` is an astropy :class:`~astropy.wcs.WCS`
             object
         hdu_index : optional int or list of int, defaults to None
-            Use this parameter to specify which HDU to tile. If the `fits`
+            Use this parameter to specify which HDU to tile. If the *image*
             input is a list of FITS, you can specify the hdu_index of each FITS
             by using a list of integers like this: [0, 2, 1]. If hdu_index is
             not set, toasty will use the first HDU with tilable content in each
@@ -273,22 +273,21 @@ class LayerManager(object):
             being processed.
         force_hipsgen : optional boolean, defaults to False
             Force the input FITS to be tiled with HiPSgen. If this and
-            `force_tan` is set to False, this method will figure out when to
+            *force_tan* are set to False, this method will figure out when to
             split the input into tiles and also which type of projection to
             use. Tangential projection for smaller angular areas and HiPSgen
             larger regions of the sky.
         force_tan : optional boolean, defaults to False
             Force the input FITS to be tiled with a tangential projection. If
-            this and `force_hipsgen` is set to False, this method will figure
+            this and *force_hipsgen* are set to False, this method will figure
             out when to split the input into tiles and also which type of
             projection to use. Tangential projection for smaller angular areas
             and HiPSgen larger regions of the sky.
         kwargs
             Additional keyword arguments can be used to set properties on the
             image layer or settings for the `toasty` tiling process. Common
-            toasty settings include `out_dir`, `override`, and `blankval`.
-            See `~toasty.tile_fits`
-            https://toasty.readthedocs.io/en/latest/api/toasty.tile_fits.html#toasty.tile_fits
+            toasty settings include ``out_dir``, ``override``, and ``blankval``.
+            See `toasty.tile_fits`.
 
         Returns
         -------

--- a/pywwt/utils.py
+++ b/pywwt/utils.py
@@ -10,7 +10,7 @@ from reproject.mosaicking import find_optimal_celestial_wcs
 __all__ = ['sanitize_image']
 
 
-def sanitize_image(image, output_file, overwrite=False, **kwargs):
+def sanitize_image(image, output_file, overwrite=False, hdu_index=None, **kwargs):
     """
     Transform a FITS image so that it is in equatorial coordinates with a TAN
     projection and floating-point values, all of which are required to work
@@ -22,8 +22,8 @@ def sanitize_image(image, output_file, overwrite=False, **kwargs):
     # In case of a FITS file with more than one HDU, we need to choose one
     if isinstance(image, str):
         with fits.open(image) as hdul:
-            if 'hdu_index' in kwargs:
-                image = hdul[kwargs.get('hdu_index')]
+            if hdu_index is not None:
+                image = hdul[hdu_index]
             else:
                 for hdu in hdul:
                     if (hasattr(hdu, 'shape') and len(hdu.shape) > 1

--- a/pywwt/utils.py
+++ b/pywwt/utils.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from reproject import reproject_interp
 from reproject.mosaicking import find_optimal_celestial_wcs
 
-__all__ = ['sanitize_image']
+__all__ = ["sanitize_image"]
 
 
 def sanitize_image(image, output_file, overwrite=False, hdu_index=None, **kwargs):
@@ -26,8 +26,11 @@ def sanitize_image(image, output_file, overwrite=False, hdu_index=None, **kwargs
                 image = hdul[hdu_index]
             else:
                 for hdu in hdul:
-                    if (hasattr(hdu, 'shape') and len(hdu.shape) > 1
-                            and type(hdu) is not fits.hdu.table.BinTableHDU):
+                    if (
+                        hasattr(hdu, "shape")
+                        and len(hdu.shape) > 1
+                        and type(hdu) is not fits.hdu.table.BinTableHDU
+                    ):
                         break
                 image = hdu
             transform_to_wwt_supported_fits(image, output_file, overwrite)
@@ -36,32 +39,35 @@ def sanitize_image(image, output_file, overwrite=False, hdu_index=None, **kwargs
 
 
 def transform_to_wwt_supported_fits(image, output_file, overwrite):
-    wcs, shape_out = find_optimal_celestial_wcs([image], frame=ICRS(),
-                                                projection='TAN')
+    wcs, shape_out = find_optimal_celestial_wcs([image], frame=ICRS(), projection="TAN")
     array = reproject_interp(image, wcs, shape_out=shape_out, return_footprint=False)
-    fits.writeto(output_file, array.astype(np.float32),
-                 wcs.to_header(), overwrite=overwrite)
+    fits.writeto(
+        output_file, array.astype(np.float32), wcs.to_header(), overwrite=overwrite
+    )
 
 
 def validate_traits(cls, traits):
-    '''
+    """
     Helper function to ensure user-provided trait names match those of the
     class they're being used to instantiate.
-    '''
+    """
     mismatch = [key for key in traits if key not in cls.trait_names()]
     if mismatch:
-        raise KeyError('Key{0} {1} do{2}n\'t match any layer trait name'
-                       .format('s' if len(mismatch) > 1 else '',
-                               mismatch,
-                               '' if len(mismatch) > 1 else 'es'))
+        raise KeyError(
+            "Key{0} {1} do{2}n't match any layer trait name".format(
+                "s" if len(mismatch) > 1 else "",
+                mismatch,
+                "" if len(mismatch) > 1 else "es",
+            )
+        )
 
 
 def ensure_utc(tm, str_allowed):
-    '''
+    """
     Helper function to convert a time object (Time, datetime, or UTC string
     if str_allowed == True) into UTC before passing it to WWT.
     str_allowed is True for wwt.set_current_time (core.py) and False for TableLayer's 'time_att' implementation (layers.py).
-    '''
+    """
 
     if tm is None:
         utc_tm = datetime.utcnow().astimezone(pytz.UTC).isoformat()
@@ -79,9 +85,9 @@ def ensure_utc(tm, str_allowed):
 
     else:
         if str_allowed:  # is an ISOT string
-            dt = Time(tm, format='isot').to_datetime(pytz.UTC)
+            dt = Time(tm, format="isot").to_datetime(pytz.UTC)
             utc_tm = dt.isoformat()
         else:
-            raise ValueError('Time must be a datetime or astropy.Time object')
+            raise ValueError("Time must be a datetime or astropy.Time object")
 
     return utc_tm

--- a/setup.py
+++ b/setup.py
@@ -11,37 +11,42 @@ import sys
 from glob import glob
 from os.path import join as pjoin
 
-sys.path.append('.')
+sys.path.append(".")
 from setupbase import (
-    create_cmdclass, install_npm, ensure_targets,
-    find_packages, combine_commands, ensure_python,
-    get_version, HERE
+    create_cmdclass,
+    install_npm,
+    ensure_targets,
+    find_packages,
+    combine_commands,
+    ensure_python,
+    get_version,
+    HERE,
 )
 
 from setuptools import setup
 
-ensure_python('>=3.7')
+ensure_python(">=3.7")
 
 # Gather package metadata.
 
-name = 'pywwt'
-version = get_version(pjoin(name, '_version.py'))
+name = "pywwt"
+version = get_version(pjoin(name, "_version.py"))
 
-with io.open('README.md', encoding='utf_8') as f:
+with io.open("README.md", encoding="utf_8") as f:
     LONG_DESCRIPTION = f.read()
 
 # Wire up the NPM build to the Python package build -- we generate JavaScript
 # artifacts from the `frontend/` package and then include them as data assets in
 # the pywwt Python package.
 
-nb_path = pjoin(name, 'nbextension', 'static')
+nb_path = pjoin(name, "nbextension", "static")
 
 js_outputs = [
-    pjoin(nb_path, 'index.js'),
+    pjoin(nb_path, "index.js"),
 ]
 
 js_content_command = combine_commands(
-    install_npm('frontend', build_cmd='pywwt-export'),
+    install_npm("frontend", build_cmd="pywwt-export"),
     ensure_targets(js_outputs),
 )
 
@@ -51,106 +56,101 @@ js_content_command = combine_commands(
 
 package_data_spec = {
     name: [
-        'interactive_figure/*.html',
-        'interactive_figure/*.js',
-        'labextension/*.tgz',
-        'nbextension/static/*.*js*',
-        'tests/data/*/*.png',
-        'tests/data/*.fits',
-        'web_static/**',
+        "interactive_figure/*.html",
+        "interactive_figure/*.js",
+        "labextension/*.tgz",
+        "nbextension/static/*.*js*",
+        "tests/data/*/*.png",
+        "tests/data/*.fits",
+        "web_static/**",
     ]
 }
 
-lab_path = pjoin(name, 'labextension')
-local_nbdotd_path = pjoin('jupyter.d', 'notebook.d')
-local_jnbcfgdotd_path = pjoin('jupyter.d', 'jupyter_notebook_config.d')
+lab_path = pjoin(name, "labextension")
+local_nbdotd_path = pjoin("jupyter.d", "notebook.d")
+local_jnbcfgdotd_path = pjoin("jupyter.d", "jupyter_notebook_config.d")
 
 data_files_spec = [
-    ('share/jupyter/nbextensions/pywwt', nb_path, '*.js*'),
-    ('share/jupyter/lab/extensions', lab_path, '*.tgz'),
-    ('etc/jupyter/nbconfig/notebook.d', local_nbdotd_path, 'pywwt.json'),
-    ('etc/jupyter/jupyter_notebook_config.d' ,local_jnbcfgdotd_path, 'pywwt.json'),
+    ("share/jupyter/nbextensions/pywwt", nb_path, "*.js*"),
+    ("share/jupyter/lab/extensions", lab_path, "*.tgz"),
+    ("etc/jupyter/nbconfig/notebook.d", local_nbdotd_path, "pywwt.json"),
+    ("etc/jupyter/jupyter_notebook_config.d", local_jnbcfgdotd_path, "pywwt.json"),
 ]
 
 cmdclass = create_cmdclass(
-    'js-content',
-    package_data_spec = package_data_spec,
-    data_files_spec = data_files_spec
+    "js-content", package_data_spec=package_data_spec, data_files_spec=data_files_spec
 )
-cmdclass['js-content'] = js_content_command
+cmdclass["js-content"] = js_content_command
 
 # Ready to go!
 
 setup_args = dict(
-    name            = name,
-    description     = 'The AAS WorldWide Telescope from Python',
-    long_description = LONG_DESCRIPTION,
-    long_description_content_type = 'text/markdown',
-    version         = version,
-    cmdclass        = cmdclass,
-    packages        = find_packages(),
-    author          = 'Thomas P. Robitaille, O. Justin Otor, and John ZuHone',
-    author_email    = 'thomas.robitaille@gmail.com',
-    url             = 'https://github.com/WorldWideTelescope/pywwt',
-    license         = 'BSD',
-    platforms       = "Linux, Mac OS X, Windows",
-    keywords        = ['Jupyter', 'Widgets', 'IPython'],
-    classifiers     = [
-        'Intended Audience :: Developers',
-        'Intended Audience :: Science/Research',
-        'License :: OSI Approved :: BSD License',
-        'Topic :: Multimedia :: Graphics',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Framework :: Jupyter',
+    name=name,
+    description="The AAS WorldWide Telescope from Python",
+    long_description=LONG_DESCRIPTION,
+    long_description_content_type="text/markdown",
+    version=version,
+    cmdclass=cmdclass,
+    packages=find_packages(),
+    author="Thomas P. Robitaille, O. Justin Otor, and John ZuHone",
+    author_email="thomas.robitaille@gmail.com",
+    url="https://github.com/WorldWideTelescope/pywwt",
+    license="BSD",
+    platforms="Linux, Mac OS X, Windows",
+    keywords=["Jupyter", "Widgets", "IPython"],
+    classifiers=[
+        "Intended Audience :: Developers",
+        "Intended Audience :: Science/Research",
+        "License :: OSI Approved :: BSD License",
+        "Topic :: Multimedia :: Graphics",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Framework :: Jupyter",
     ],
-    include_package_data = True,
-    python_requires = '>=3.7',
-    install_requires = [
+    include_package_data=True,
+    python_requires=">=3.7",
+    install_requires=[
         # Keep alphabetized:
-        'astropy>=1.0,!=4.0.1',
-        'beautifulsoup4',
-        'ipyevents',
-        'ipywidgets>=7.0.0',
-        'lxml',
-        'matplotlib>1.5',
-        'nest_asyncio',
-        'numpy>=1.9',
-        'python-dateutil',
-        'pytz',
-        'qtpy',
-        'reproject>=0.8',
-        'requests',
-        'toasty>=0.13.0',
-        'tornado',
-        'traitlets>=5',
+        "astropy>=1.0,!=4.0.1",
+        "beautifulsoup4",
+        "ipyevents",
+        "ipywidgets>=7.0.0",
+        "lxml",
+        "matplotlib>1.5",
+        "nest_asyncio",
+        "numpy>=1.9",
+        "python-dateutil",
+        "pytz",
+        "qtpy",
+        "reproject>=0.8",
+        "requests",
+        "toasty>=0.13.0",
+        "tornado",
+        "traitlets>=5",
     ],
-    extras_require = {
-        'test': [
-            'pytest',
-            'pytest-cov>=2.6.1',
-            'pytest-remotedata>=0.3.1',
+    extras_require={
+        "test": [
+            "pytest",
+            "pytest-cov>=2.6.1",
+            "pytest-remotedata>=0.3.1",
         ],
-        'docs': [
-            'astropy-sphinx-theme',
-            'sphinx>=1.6',
-            'sphinx-automodapi',
-            'numpydoc',
-            'jupyter_sphinx',
+        "docs": [
+            "astropy-sphinx-theme",
+            "sphinx>=1.6",
+            "sphinx-automodapi",
+            "numpydoc",
+            "jupyter_sphinx",
         ],
-        'qt': [
+        "qt": [
             'PyQt5;python_version>="3"',
             'PyQtWebEngine;python_version>="3"',
         ],
-        'lab': [
-            'jupyterlab'
-        ]
+        "lab": ["jupyterlab"],
     },
-    entry_points = {
-    },
+    entry_points={},
 )
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     setup(**setup_args)

--- a/setup.py
+++ b/setup.py
@@ -126,7 +126,7 @@ setup_args = dict(
         "qtpy",
         "reproject>=0.8",
         "requests",
-        "toasty>=0.13.0",
+        "toasty>=0.14.0",
         "tornado",
         "traitlets>=5",
     ],


### PR DESCRIPTION
Adapted add_image_layer for new toasty functionality (including HiPSgen) https://github.com/WorldWideTelescope/toasty/pull/69

- hdu_index can now also be a list
- Previous usage of hdu_index with non-tiled FITS caused KeyError by ImageLayer's validate_traits. Now fixed by a kwargs.pop. 

@pkgw Can you think of a better way of dealing with the toasty keywords? Right now, they are manually popped in _remove_toasty_keywords, which doesn't feel too stable. At the same time validating the traits sent to ImageLayer seems like a useful thing to do. And exposing all toasty settings explicitly in the add_image_layer does not seem optimal either.  Let me know what you think.