### PR TITLE
Fix Kernel Data Relay sequence numbers on errors

### DIFF
--- a/ci/azure-build-and-test.yml
+++ b/ci/azure-build-and-test.yml
@@ -113,9 +113,27 @@ jobs:
       env:
         PYWWT_TEST_IMAGE_DIR: $(Build.ArtifactStagingDirectory)
 
+    # We used to publish the test image artifacts regardless of whether the test
+    # succeeded or failed (using `condition: true`). This led to an annoying
+    # behavior, though, where if an image test failed spuriously, you'd have to
+    # rerun the entire build: if the test succeeded the next time, the
+    # publication step would fail because you can't upload artifacts under the
+    # same name more than once. So now, we only publish the images if the tests
+    # failed: that way, "rerun failed jobs" will be able to resolve a spurious
+    # failure efficiently. This is especially valuable in Cranko release and RC
+    # builds. If an image test fails *non*-spuriously, you'll only be able to
+    # obtain artifacts from the first failure in given build ... but that was
+    # what was happening with `condition: true` anyway.
+    #
+    # We might want to turn this into some kind of top-level pipeline parameter
+    # because I think there will be occasions where it would be nice to gather
+    # the image data for all of the image tests, including the successful ones.
+    # But that's more of a once-in-a-long-while thing, while the rerun issue
+    # rears in say ~5% of PR builds.
+
     - task: PublishPipelineArtifact@1
-      displayName: Publish generated test images
-      condition: true  # run even (especially!) if test fails
+      displayName: Publish failing test images
+      condition: not(succeeded())
       inputs:
         targetPath: $(Build.ArtifactStagingDirectory)
         artifactName: ${{ format('test_images_{0}', build.name) }}

--- a/ci/azure-build-and-test.yml
+++ b/ci/azure-build-and-test.yml
@@ -210,8 +210,7 @@ jobs:
       source activate-conda.sh
       conda activate build
       set -x
-      \conda install -y astropy jupyter_sphinx numpydoc sphinx sphinx-automodapi sphinx_rtd_theme
-      pip install astropy-sphinx-theme
+      \conda install -y astropy astropy-sphinx-theme jupyter_sphinx numpydoc sphinx sphinx-automodapi
       cd docs
       make html
     displayName: Build docs

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -44,7 +44,7 @@ deadline.
 If you aren’t using a conda-based Python environment, it’s easy to set one up.
 The `Anaconda Distribution <https://www.anaconda.com/products/individual>`_ is
 popular and widely supported, or you can use `Miniforge
-<https://github.com/conda-forge/miniforge#install>`_ or `Miniconda
+<https://github.com/conda-forge/miniforge#user-content-install>`_ or `Miniconda
 <https://docs.conda.io/en/latest/miniconda.html>`_ for a smaller download. These
 environments install in a fully self-contained manner, so you can try them out
 without modifying your computer’s existing Python installation(s).


### PR DESCRIPTION
<!-- Thank you for your pull request! Please summarize it with the following form. -->

### Overview

When testing the new HiPSgen tiling code, I ran into at least one variant of the KDR issues reported by @imbasimba . 404s weren't being handled properly because pywwt wasn't including sequence numbers in its error messages.

Also tidy up some documentation infrastructure in the aftermath of #318 and the hotfixes pushed straight to master.