### PR TITLE
Increased jupyter-relay chunk size to 8MB

### DIFF
--- a/pywwt/jupyter_relay.py
+++ b/pywwt/jupyter_relay.py
@@ -322,7 +322,7 @@ class JupyterRelayHub(object):
 
             while keep_going:
                 # The chunk size here is just a guess:
-                chunk = handle.read(32768)
+                chunk = handle.read(8388608)
 
                 if len(chunk):
                     buffers = [chunk]

--- a/pywwt/jupyter_relay.py
+++ b/pywwt/jupyter_relay.py
@@ -321,8 +321,14 @@ class JupyterRelayHub(object):
             keep_going = True
 
             while keep_going:
-                # The chunk size here is just a guess:
-                chunk = handle.read(8388608)
+                # There is some kind of message limit (max 2000 at the same time) on the receiving end.
+                # So we want so send as few messages as possible to never reach that limit.
+                # Even if the messages are sent correctly, only the first 2000 are received by KDR.
+                # We cannot just make sure that every single request consists of less than 2000 messages,
+                # since other requests seem to be fighting for the same 2000 spots.
+                # So I felt like it is safest to up the chunk size to something very, very high.
+                # At least until the root issue is found and resolved.
+                chunk = handle.read(8388608) # 8MB
 
                 if len(chunk):
                     buffers = [chunk]


### PR DESCRIPTION
I have not found the root cause of this issue, but increasing the chunk size to something ridiculously high, like 8MB should make this error extremely unlikely.

What I found during the investigation is that the messages are all sent correctly, but only the first 2000 are received by KDR.

In some rare instances, when multiple requests are fired almost simultaneously, less than 2000 are received. This has led me to believe that the limit is on the receiving end, so we cannot just make sure that every single request is less than 2000 messages, since all the requests are fighting for the same 2000 spots. So I felt like it is safest to up the chunk size to something very, very high. At least until the root issue is found and resolved.
