### PR TITLE
Removed pywwt.annotation.rst

### DIFF
--- a/docs/api/pywwt.annotation.rst
+++ b/docs/api/pywwt.annotation.rst
@@ -1,3 +1,0 @@
-.. automodapi:: pywwt.annotation
-   :no-inheritance-diagram:
-   :no-inherited-members:

--- a/docs/api/pywwt.annotation_.rst
+++ b/docs/api/pywwt.annotation_.rst
@@ -1,0 +1,3 @@
+.. automodapi:: pywwt.annotation
+   :no-inheritance-diagram:
+   :no-inherited-members:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -74,7 +74,7 @@ API Reference
    :maxdepth: 1
 
    api/pywwt
-   api/pywwt.annotation
+   api/pywwt.annotation_
    api/pywwt.app
    api/pywwt.core
    api/pywwt.data_server


### PR DESCRIPTION
I'm not entirely sure why there are two pywwt.annotation.rst, but the are fighting each other since they have the same name with different capitalization (pywwt.**a**nnotation.rst vs pywwt.**A**nnotation.rst)

So I deleted one, but maybe there is a better solution?
