### PR TITLE
Allow time_decay attribute of layers to be serialized

### DIFF
--- a/pywwt/layers.py
+++ b/pywwt/layers.py
@@ -1319,6 +1319,8 @@ class TableLayer(HasTraits):
             wwt_name = trait.metadata.get("wwt")
             if wwt_name:
                 value = trait.get(self)
+                if wwt_name == "decay" and value is not None:
+                    value = value.to(u.day).value
                 if wwt_name == "raUnits" and value is not None:
                     value = VALID_LON_UNITS[value]
                 elif wwt_name == "altUnit" and value is not None:

--- a/pywwt/tests/test_serialization.py
+++ b/pywwt/tests/test_serialization.py
@@ -446,7 +446,7 @@ def test_table_setting_serialization():
                          'latColumn': 'dec',
                          'altColumn': 'flux',
                          'timeSeries': False,
-                         'decay': 16 * u.day,
+                         'decay': 16,
                          'altUnit': None,
                          'altType': 'distance',
                          'color': '#aacc00',


### PR DESCRIPTION
This PR allows the `time_decay` property of a table layer to be serialized - currently, using `_serialize_state` if the WWT widget is displaying a table layer will throw an error as it doesn't know how to serialize an astropy `Quantity`. The conversion is the same as is used in `_on_trait_change` [here](https://github.com/WorldWideTelescope/pywwt/blob/master/pywwt/layers.py#L1305).

The motivation is to allow `save_as_html_bundle` to work, with https://github.com/glue-viz/glue-wwt/pull/62 being a particular case where this functionality would be used. It would be nice to have the exported bundle use the research app, but I suspect that will take a nontrivial amount of effort.