### PR TITLE
Add Zenodo auto-deposit for DOI registration

### DIFF
--- a/ci/azure-deployment.yml
+++ b/ci/azure-deployment.yml
@@ -110,3 +110,34 @@ jobs:
       displayName: Publish to NPM
     - bash: shred ~/.npmrc
       displayName: Clean up credentials
+
+  - job: zenodo_publish
+    pool:
+      vmImage: ubuntu-20.04
+    variables:
+    - group: Deployment Credentials
+
+    steps:
+    - template: azure-job-setup.yml
+      parameters:
+        setupCranko: true
+
+    - bash: |
+        set -xeuo pipefail
+
+        if cranko show if-released --exit-code pypa:pywwt ; then
+          cranko zenodo upload-artifacts --metadata=ci/zenodo.json5 $BASH_WORKSPACE/sdist/*.tar.gz
+        fi
+      displayName: Upload source tarball
+      env:
+        ZENODO_TOKEN: $(ZENODO_TOKEN)
+
+    - bash: |
+        set -xeuo pipefail
+
+        if cranko show if-released --exit-code pypa:pywwt ; then
+          cranko zenodo publish --metadata=ci/zenodo.json5
+        fi
+      displayName: Publish to Zenodo
+      env:
+        ZENODO_TOKEN: $(ZENODO_TOKEN)

--- a/ci/azure-sdist.yml
+++ b/ci/azure-sdist.yml
@@ -6,6 +6,13 @@ jobs:
   pool:
     vmImage: ubuntu-20.04
 
+  # Need Zenodo credentials to generate DOIs during formal releases. But make
+  # sure not to provide credentials otherwise (although Azure has its own checks
+  # to not provide secrets during PR builds).
+  ${{ if and(eq(variables['Build.SourceBranchName'], 'rc'), ne(variables['build.reason'], 'PullRequest')) }}:
+    variables:
+    - group: Deployment Credentials
+
   steps:
 
   - checkout: self
@@ -18,9 +25,18 @@ jobs:
       echo "##vso[task.prependpath]$d"
     displayName: Install latest Cranko
 
+  - bash: cranko release-workflow apply-versions
+    displayName: Apply Cranko versions
+
+  - bash: |
+      cranko zenodo preregister --metadata=ci/zenodo.json5 pypa:pywwt pywwt/_version.py CHANGELOG.md
+    displayName: "Preregister Zenodo DOI"
+    ${{ if and(eq(variables['Build.SourceBranchName'], 'rc'), ne(variables['build.reason'], 'PullRequest')) }}:
+      env:
+          ZENODO_TOKEN: $(ZENODO_TOKEN)
+
   - bash: |
       set -xeuo pipefail
-      cranko release-workflow apply-versions
       git add .
       cranko release-workflow commit
       git show

--- a/ci/zenodo.json5
+++ b/ci/zenodo.json5
@@ -16,7 +16,7 @@
         orcid: '0000-0002-7759-2601',
       },
       {
-        affiliation: 'Universität Heidelberg',
+        affiliation: 'Heidelberg Institute for Theoretical Studies',
         name: 'Gaibler, Volker',
         orcid: '0000-0001-7581-7574',
       },

--- a/ci/zenodo.json5
+++ b/ci/zenodo.json5
@@ -28,6 +28,7 @@
       {
         affiliation: 'Space Telescope Science Institute',
         name: 'Otor, O. Justin',
+        orcid: '0000-0002-4679-5692',
       },
       {
         affiliation: 'Aperio Software',

--- a/ci/zenodo.json5
+++ b/ci/zenodo.json5
@@ -60,8 +60,13 @@ Telescope (WWT) from Python. Learn more at <a href="https://pywwt.readthedocs.io
     grants: [
       // National Science Foundation:
       {id: '10.13039/100000001::1550701'},
-      {id: '10.13039/100000001::1642446'},
-      {id: '10.13039/100000001::2004840'},
+
+      // As of 2022 August these grants are not in the OpenAIRE "Research Graph"
+      // and so Zenodo won't let us record them here. Test existence by
+      // GET'ing `https://zenodo.org/api/grants/$id`.
+      //
+      //{id: '10.13039/100000001::1642446'},
+      //{id: '10.13039/100000001::2004840'},
     ],
 
     // Keywords use an uncontrolled vocabulary (and so are of limited usefulness):

--- a/ci/zenodo.json5
+++ b/ci/zenodo.json5
@@ -1,0 +1,72 @@
+// See https://pkgw.github.io/cranko/book/latest/integrations/zenodo.html
+// and https://developers.zenodo.org/#representation
+
+{
+  conceptrecid: 'new-for:0.16.0',
+
+  metadata: {
+    upload_type: 'software',
+    language: 'eng',
+
+    // ** Keep this alphabetical by family name!!! **
+    creators: [
+      {
+        affiliation: 'Center for Astrophysics | Harvard & Smithsonian',
+        name: 'Carifio, Jonathan',
+      },
+      {
+        affiliation: 'Universität Heidelberg',
+        name: 'Gaibler, Volker',
+      },
+      {
+        affiliation: 'Winter Way',
+        name: 'Norman, Henrik',
+        orcid: '0000-0003-4189-3450',
+      },
+      {
+        affiliation: 'Space Telescope Science Institute',
+        name: 'Otor, O. Justin',
+      },
+      {
+        affiliation: 'Aperio Software',
+        name: 'Robitaille, Thomas P.',
+        orcid: '0000-0002-8642-1329',
+      },
+      {
+        name: 'Subbarao, Jeffrey',
+      },
+      {
+        affiliation: 'Center for Astrophysics | Harvard & Smithsonian',
+        name: 'Williams, Peter K. G.',
+        orcid: '0000-0003-3734-3587',
+      },
+      {
+        affiliation: 'Center for Astrophysics | Harvard & Smithsonian',
+        name: 'ZuHone, Jonathan',
+        orcid: '0000-0003-3175-2347',
+      },
+    ],
+
+    // Subset of HTML allowed here:
+    description: 'pywwt is the official toolkit for accessing AAS WorldWide \
+Telescope (WWT) from Python. Learn more at <a href="https://pywwt.readthedocs.io/">the pywwt website</a>.',
+
+    access_right: 'open',
+    license: 'BSD-3-Clause', // see https://spdx.org/licenses/
+
+    grants: [
+      // National Science Foundation:
+      {id: '10.13039/100000001::1550701'},
+      {id: '10.13039/100000001::1642446'},
+      {id: '10.13039/100000001::2004840'},
+    ],
+
+    // Keywords use an uncontrolled vocabulary (and so are of limited usefulness):
+    keywords: [
+      'AAS WorldWide Telescope',
+      'Astronomy',
+      'Python',
+      'Visualization',
+    ],
+  },
+}

--- a/ci/zenodo.json5
+++ b/ci/zenodo.json5
@@ -17,6 +17,7 @@
       {
         affiliation: 'Universität Heidelberg',
         name: 'Gaibler, Volker',
+        orcid: '0000-0001-7581-7574',
       },
       {
         affiliation: 'Winter Way',

--- a/ci/zenodo.json5
+++ b/ci/zenodo.json5
@@ -45,7 +45,7 @@
       },
       {
         affiliation: 'Center for Astrophysics | Harvard & Smithsonian',
-        name: 'ZuHone, Jonathan',
+        name: 'ZuHone, John',
         orcid: '0000-0003-3175-2347',
       },
     ],

--- a/ci/zenodo.json5
+++ b/ci/zenodo.json5
@@ -13,6 +13,7 @@
       {
         affiliation: 'Center for Astrophysics | Harvard & Smithsonian',
         name: 'Carifio, Jonathan',
+        orcid: '0000-0002-7759-2601',
       },
       {
         affiliation: 'Universität Heidelberg',

--- a/pywwt/_version.py
+++ b/pywwt/_version.py
@@ -18,5 +18,5 @@ __version__ = "%s.%s.%s%s" % (
 )
 
 # The strings are auto-updated by Cranko during formal releases:
-version_doi = "xx.xxxx/dev-build.cranko.version"
-concept_doi = "xx.xxxx/dev-build.cranko.concept"
+version_doi = "xx.xxxx/dev-build.pypa:pywwt.version"
+concept_doi = "xx.xxxx/dev-build.pypa:pywwt.concept"

--- a/pywwt/_version.py
+++ b/pywwt/_version.py
@@ -16,3 +16,7 @@ __version__ = "%s.%s.%s%s" % (
     if version_info[3] == "final"
     else _specifier_[version_info[3]] + str(version_info[4]),
 )
+
+# The strings are auto-updated by Cranko during formal releases:
+version_doi = "xx.xxxx/dev-build.cranko.version"
+concept_doi = "xx.xxxx/dev-build.cranko.concept"

--- a/pywwt/_version.py
+++ b/pywwt/_version.py
@@ -1,10 +1,18 @@
-version_info = (0, 0, 0, 'dev', 0)  # cranko project-version tuple
+version_info = (0, 0, 0, "dev", 0)  # cranko project-version tuple
 
-_specifier_ = {'alpha': '.a', 'beta': '.b', 'candidate': '.rc', 'final': '', 'dev': '.dev'}
+_specifier_ = {
+    "alpha": ".a",
+    "beta": ".b",
+    "candidate": ".rc",
+    "final": "",
+    "dev": ".dev",
+}
 
-__version__ = '%s.%s.%s%s' % (
+__version__ = "%s.%s.%s%s" % (
     version_info[0],
     version_info[1],
     version_info[2],
-    '' if version_info[3] == 'final' else _specifier_[version_info[3]]+str(version_info[4])
+    ""
+    if version_info[3] == "final"
+    else _specifier_[version_info[3]] + str(version_info[4]),
 )

--- a/setup.py
+++ b/setup.py
@@ -142,7 +142,10 @@ setup_args = dict(
             'PyQt5;python_version>="3"',
             'PyQtWebEngine;python_version>="3"',
         ],
-        "lab": ["jupyterlab"],
+        "lab": [
+            "jupyterlab",
+            "notebook",
+        ],
     },
     entry_points={},
 )


### PR DESCRIPTION
<!-- Thank you for your pull request! Please summarize it with the following form. -->

### Overview

Add automated Zenodo deposition to mint DOIs for pywwt releases.

Minting DOIs implies maintaining a formal author list. For that, I've included everyone who's ever committed to the repository, alphabetically by family name. But I won't list people without their permission. **If you'd like to be included as an author, please comment on this PR to that effect**, and review what I've put for your name, affiliation, and ORCID:

- [x] @Carifio24
- [x] @vga101
- [x] @imbasimba 
- [x] @ojustino 
- [x] @astrofrog
- [x] @jsub1
- [x] @pkgw (me)
- [x] @jzuhone

It might take me a couple of tries to get the CI/CD automation to fully work, but hopefully it will be straightforward since I've gotten it going for the Cranko tool itself.