### PR TITLE
Allow toggling whether a table layer is selectable

### DIFF
--- a/pywwt/layers.py
+++ b/pywwt/layers.py
@@ -712,6 +712,12 @@ class TableLayer(HasTraits):
         "(:class:`~astropy.units.Quantity`)",
     ).tag(wwt="decay")
 
+    selectable = Bool(
+        True,
+        help="Whether sources in the layer "
+        "are selectable (`bool`)"
+    ).tag(wwt=None)
+
     # TODO: support:
     # xAxisColumn
     # yAxisColumn
@@ -1218,6 +1224,15 @@ class TableLayer(HasTraits):
             id=self.id,
             setting="startDateColumn",
             value=TIME_COLUMN_NAME,
+        )
+
+    @observe("selectable")
+    def _on_selectable_change(self, changed):
+        if not self.notify_changes:
+            return
+
+        self.parent._send_msg(
+            type="modify_selectability", id=self.id, selectable=changed["new"]
         )
 
     def _get_table(self):


### PR DESCRIPTION
This PR adds the ability to select whether or not a table layer is selectable - basically, exposing the functionality from https://github.com/WorldWideTelescope/wwt-webgl-engine/pull/183. As in that PR, allowing client applications to make layers non-selectable should help performance when there are a lot of points, with `glue-wwt` being one example of an application that can benefit from having layers be non-selectable most of the time. To make this possible, I've added a boolean `selectable` traitlet to the table layer class. Since selectability is a property at the research app level, rather than of the engine layer, I've set `wwt=None` in the traitlet metadata.