### PR TITLE
Update interactive figure export to account for named colormaps

### DIFF
--- a/pywwt/layers.py
+++ b/pywwt/layers.py
@@ -1371,11 +1371,20 @@ class TableLayer(HasTraits):
                 state["settings"][wwt_name] = value
 
         if self._uniform_color():
-            state["settings"]["_colorMap"] = 0
+            state["settings"]["colorMap"] = 0
             state["settings"]["colorMapColumn"] = -1
+        elif self.cmap.name.lower() in VALID_COLORMAPS:
+            state["settings"]["colorMap"] = 3
+            state["settings"]["colorMapperName"] = self.cmap.name
+            state["settings"]["dynamicColor"] = True
+            state["settings"]["normalizeColorMap"] = True
+            state["settings"]["normalizeColorMapMin"] = self.cmap_vmin
+            state["settings"]["normalizeColorMapMax"] = self.cmap_vmax
+            state["settings"]["colorMapColumn"] = self.cmap_att
         else:
-            state["settings"]["_colorMap"] = 3
+            state["settings"]["colorMap"] = 3
             state["settings"]["colorMapColumn"] = CMAP_COLUMN_NAME
+            state["settings"]["dynamicColor"] = False
 
         if self._uniform_size():
             state["settings"]["sizeColumn"] = -1

--- a/pywwt/tests/test_serialization.py
+++ b/pywwt/tests/test_serialization.py
@@ -1,7 +1,7 @@
 import pytest
 
 from ..core import BaseWWTWidget
-from ..layers import SIZE_COLUMN_NAME, CMAP_COLUMN_NAME
+from ..layers import SIZE_COLUMN_NAME
 
 import numpy as np
 import os
@@ -456,7 +456,7 @@ def test_table_setting_serialization():
                          'markerScale': 'world',
                          'showFarSide': True,
                          'sizeColumn': -1,
-                         '_colorMap': 0,
+                         'colorMap': 0,
                          'colorMapColumn': -1,
                          'xAxisColumn': '',
                          'yAxisColumn': '',
@@ -472,9 +472,14 @@ def test_table_setting_serialization():
 
     expected_settings['sizeColumn'] = SIZE_COLUMN_NAME
     expected_settings['pointScaleType'] = 0
-    expected_settings['colorMapColumn'] = CMAP_COLUMN_NAME
-    expected_settings['_colorMap'] = 3
+    expected_settings['colorMapColumn'] = layer.cmap_att
+    expected_settings['colorMap'] = 3
     expected_settings['altUnit'] = 'megaParsecs'
+    expected_settings['dynamicColor'] = True
+    expected_settings['colorMapperName'] = 'viridis'
+    expected_settings["normalizeColorMap"] = True
+    expected_settings["normalizeColorMapMin"] = layer.cmap_vmin
+    expected_settings["normalizeColorMapMax"] = layer.cmap_vmax
 
     assert widget.quick_serialize()['layers'][0]['settings'] == expected_settings
 


### PR DESCRIPTION
This PR fixes a bug in the interactive figure export where named colormaps are not exported correctly. This is a pretty straightforward change, we just need to make sure to account for all of the relevant settings, which I did by mimicking the logic [here](https://github.com/WorldWideTelescope/pywwt/blob/master/pywwt/layers.py#L1126).

Also, I changed `"_colorMap"` to `"colorMap"` in the other two cases because using `"_colorMap"` doesn't call the setter correctly (since it's `set_colorMap` rather than `set__colorMap`).