### PR TITLE
Move re-flag in `_translate_glob` to front to build with Python 3.11

### DIFF
--- a/setupbase.py
+++ b/setupbase.py
@@ -636,7 +636,7 @@ def _translate_glob(pat):
         translated_parts.append(_translate_glob_part(part))
     os_sep_class = "[%s]" % re.escape(SEPARATORS)
     res = _join_translated(translated_parts, os_sep_class)
-    return "{res}\\Z(?ms)".format(res=res)
+    return f"(?ms){res}\\Z"
 
 
 def _join_translated(translated_parts, os_sep_class):


### PR DESCRIPTION
### Overview
Building with Python 3.11 currently fails at
```python
File "/Users/derek/git/pywwt/setupbase.py", line 613, in _compile_pattern
    return re.compile(res, flags=flags).match
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/lib/python3.11/re/__init__.py", line 227, in compile
    return _compile(pattern, flags)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/lib/python3.11/re/__init__.py", line 294, in _compile
    p = _compiler.compile(pattern, flags)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/lib/python3.11/re/_compiler.py", line 743, in compile
    p = _parser.parse(p, flags)
        ^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/lib/python3.11/re/_parser.py", line 980, in parse
    p = _parse_sub(source, state, flags & SRE_FLAG_VERBOSE, 0)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/lib/python3.11/re/_parser.py", line 455, in _parse_sub
    itemsappend(_parse(source, state, verbose, nested + 1,
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/lib/python3.11/re/_parser.py", line 841, in _parse
    raise source.error('global flags not at the start '
re.error: global flags not at the start of the expression at position 34
```
i.e. at the pattern "{res}\Z(?ms)' putting the `(?ms)` modifier at the end, which has been disallowed in
https://docs.python.org/3.11/library/re.html#regular-expression-syntax

Moving the flag to the front allows to build and pip-install. I have only tested this back to Python 3.9.

### Checklist

<!-- Go ahead and remove any of the following checkboxes if they truly do not
    apply to your proposed changes. -->

- [ ] Changed code has some test coverage (or justify why not)
- [ ] Changes in functionality documented (or justify why not)
