### PR TITLE
Fallback directory for image layers

### DIFF
--- a/pywwt/layers.py
+++ b/pywwt/layers.py
@@ -1,7 +1,7 @@
 import sys
 import uuid
 import tempfile
-from os import path, access, W_OK, getcwd
+from os import path
 import shutil
 import asyncio
 
@@ -247,7 +247,13 @@ class LayerManager(object):
 
     def _write_image_for_toasty(self, image, hdu_index=None):
         filename = self._toasty_filename(image, hdu_index=hdu_index)
+
         try:
+            # If the magic filename already exists, assume that we've already
+            # written out the image, and save time by not rewriting this.
+            # Ideally we'd write out the image to a temporary path and rename
+            # atomically to avoid the risk of trying to read an image that some
+            # other process has only half-written.
             if not Path(filename).is_file():
                 image.writeto(filename)
             return filename

--- a/pywwt/tests/test_layers.py
+++ b/pywwt/tests/test_layers.py
@@ -619,6 +619,7 @@ def test_image_tmpdir_fallback(wwt_qt_client_isolated):
     wwt = wwt_qt_client_isolated
     tmpdir = TemporaryDirectory()
     path = tmpdir.name
+    cwd = os.getcwd()
     os.chdir(path)
 
     array, wcs = _setup_image_layer_equ(wwt)
@@ -639,3 +640,4 @@ def test_image_tmpdir_fallback(wwt_qt_client_isolated):
     assert filepath == os.path.join(wwt.layers._tmpdir.name, toasty_filename)
 
     os.chmod(path, current)
+    os.chdir(cwd)

--- a/pywwt/tests/test_layers.py
+++ b/pywwt/tests/test_layers.py
@@ -615,7 +615,9 @@ def test_image_layer_fitsfile(wwt_qt_client_isolated):
 
 @pytest.mark.skipif("not QT_INSTALLED")
 def test_image_tmpdir_fallback(wwt_qt_client_isolated):
-    
+    """Ideally this test wouldn't require Qt, but we don't have the
+    infrastructure to avoid that right now."""
+
     wwt = wwt_qt_client_isolated
     tmpdir = TemporaryDirectory()
     path = tmpdir.name


### PR DESCRIPTION
Currently, if the `image` argument of `add_image_layer`is something FITS-y, the image is written to disk to allow caching for Toasty. This causes a problem if the working directory is not writable. To work around that, this PR checks first if the working directory is writable. If not, the file is written to a temporary directory instead.

This temporary directory is stored as a member value on the layer manager. This way only one directory is created, and it can be cleaned up when the layer manager is destroyed.