### PR TITLE
Update ecliptic grid color default

### DIFF
--- a/.check_enabled.py
+++ b/.check_enabled.py
@@ -2,22 +2,32 @@ import logging
 import sys
 
 from jupyterlab.commands import get_app_info
-from notebook.nbextensions import validate_nbextension
-from notebook.serverextensions import validate_serverextension
+
+try:
+    from nbclassic.nbextensions import validate_nbextension
+except ImportError:
+    # `notebook` <= 6
+    from notebook.nbextensions import validate_nbextension
+
+try:
+    from nbclassic.serverextensions import validate_serverextension
+except ImportError:
+    # `notebook` <= 6
+    from notebook.serverextensions import validate_serverextension
 
 # If there's a problem and we don't provide this, the validate function crashes :-(
-logger = logging.getLogger('')
+logger = logging.getLogger("")
 
-if validate_nbextension('pywwt/extension', logger=logger) != []:
+if validate_nbextension("pywwt/extension", logger=logger) != []:
     print("Issue detected with nbextension")
     sys.exit(1)
 
 info = get_app_info()
 
-if 'pywwt' not in info['extensions'] or 'pywwt' in info['disabled']:
+if "pywwt" not in info["extensions"] or "pywwt" in info["disabled"]:
     print("Issue detected with labextension")
     sys.exit(1)
 
-if validate_serverextension('pywwt', logger=logger) != []:
+if validate_serverextension("pywwt", logger=logger) != []:
     print("Issue detected with serverextension")
     sys.exit(1)

--- a/.readthedocs_env.yml
+++ b/.readthedocs_env.yml
@@ -14,6 +14,7 @@ dependencies:
   - krb5
   - lxml
   - matplotlib
+  - nbclassic
   - nodejs
   - notebook
   - numpydoc

--- a/ci/azure-build-and-test.yml
+++ b/ci/azure-build-and-test.yml
@@ -144,9 +144,9 @@ jobs:
         source activate-conda.sh
         conda activate build
         set -x
-        \conda install -y jupyterlab jupyter_contrib_nbextensions
-        jupyter nbextension list
-        jupyter serverextension list
+        \conda install -y jupyterlab nbclassic
+        jupyter nbclassic-extension list
+        jupyter nbclassic-serverextension list
         jupyter labextension list
       displayName: Print Jupyter extension status
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -244,13 +244,18 @@ this repository and install the package manually (note that this requires `npm
     cd pywwt
     pip install -e .
 
-If you want to use the Jupyter widget, you will also need to run::
+If you want to use the Jupyter widget with a recent installation of the Jupyter
+stack, you will also need to run::
 
-    jupyter nbextension install --py --symlink --sys-prefix pywwt
-    jupyter nbextension enable --py --sys-prefix pywwt
-    jupyter nbextension list  # check that the output shows pywwt as enabled and OK
-    jupyter serverextension enable --py --sys-prefix pywwt
-    jupyter serverextension list  # check that the output shows pywwt as enabled and OK
+    jupyter nbclassic-extension install --py --symlink --sys-prefix pywwt
+    jupyter nbclassic-extension enable --py --sys-prefix pywwt
+    jupyter nbclassic-extension list  # check that the output shows pywwt as enabled and OK
+    jupyter nbclassic-serverextension enable --py --sys-prefix pywwt
+    jupyter nbclassic-serverextension list  # check that the output shows pywwt as enabled and OK
+
+On older versions of Jupyter, use the ``nbextension`` subcommand instead of
+``nbclassic-extension``, and use just ``serverextension`` instead of
+``nbclassic-serverextension``.
 
 And if you additionally want to use the widget in JupyterLab, run::
 

--- a/pywwt/core.py
+++ b/pywwt/core.py
@@ -680,7 +680,7 @@ class BaseWWTWidget(HasTraits):
     ).tag(wwt="showEclipticGrid", wwt_reset=True)
 
     ecliptic_grid_color = Color(
-        "blue", help="The color of the ecliptic grid " "(`str` or `tuple`)"
+        "green", help="The color of the ecliptic grid " "(`str` or `tuple`)"
     ).tag(wwt="eclipticGridColor", wwt_reset=True)
 
     ecliptic_text = Bool(

--- a/pywwt/jupyter_relay.py
+++ b/pywwt/jupyter_relay.py
@@ -519,10 +519,15 @@ def get_relay_hub(kernel=None):
 def _list_running_servers_jl3():
     import io
     import json
-    from notebook.utils import check_pid
     from jupyter_core.paths import jupyter_runtime_dir
     import os.path
     import re
+
+    try:
+        from jupyter_server.utils import check_pid
+    except ImportError:
+        # `notebook` <= 6
+        from notebook.utils import check_pid
 
     runtime_dir = jupyter_runtime_dir()
 

--- a/pywwt/jupyter_server.py
+++ b/pywwt/jupyter_server.py
@@ -19,12 +19,21 @@ from tornado import web
 # so let's try to fail gracefully if Jupyter modules are missing. `tornado` is a
 # hard requirement appearing in setup.py.
 try:
-    from notebook.utils import url_path_join
-    from notebook.base.handlers import IPythonHandler
+    try:
+        from jupyter_server.utils import url_path_join
+    except ImportError:
+        # `notebook` <= 6
+        from notebook.utils import url_path_join
+
+    try:
+        from jupyter_server.base.handlers import JupyterHandler
+    except ImportError:
+        # `notebook` <= 6
+        from notebook.base.handlers import IPythonHandler as JupyterHandler
 
     HAVE_NOTEBOOK = True
 except ImportError:
-    IPythonHandler = object
+    JupyterHandler = object
     HAVE_NOTEBOOK = False
 
 __all__ = [
@@ -35,7 +44,7 @@ __all__ = [
 STATIC_DIR = os.path.join(os.path.dirname(__file__), "web_static")
 
 
-class WWTStaticFileHandler(IPythonHandler):
+class WWTStaticFileHandler(JupyterHandler):
     def get(self, filename):
         static_path = os.path.join(STATIC_DIR, filename)
 


### PR DESCRIPTION
With all the colors getting exposed in #355, I accidentally gave the ecliptic grid the wrong starting color (maybe got it mixed up with the ecliptic color?) - it should be [green](https://github.com/WorldWideTelescope/wwt-webgl-engine/blob/master/engine/wwtlib/Settings.cs#L358), rather than blue, to match the engine. This PR fixes that.