### PR TITLE
Try to fix ReadTheDocs again

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,18 +1,17 @@
 version: 2
 
 build:
-  image: latest
+  os: ubuntu-22.04
+  tools:
+    python: mambaforge-4.10
+    nodejs: "18"
   apt_packages:
     - libpci-dev
-
-# As of June 2021, We need to set up a conda environment to install
-# a sufficiently new Node.js: https://github.com/readthedocs/readthedocs.org/issues/8249
 
 conda:
   environment: .readthedocs_env.yml
 
 python:
-  version: 3.8
   install:
     - method: pip
       path: .

--- a/.readthedocs_env.yml
+++ b/.readthedocs_env.yml
@@ -5,31 +5,21 @@ channels:
 dependencies:
   - astropy
   - astropy-sphinx-theme
-  - commonmark
   - ipyevents
-  - ipython
-  - ipywidgets
-  - jupyterlab
-  - jupyterlab_widgets
-  - krb5
-  - lxml
   - ipykernel
+  - ipywidgets
+  - lxml
   - matplotlib
   - nbclassic
-  - nodejs
-  - notebook
   - numpydoc
   - pip
   - pyopengl
   - pyqt
   - pyqtwebengine
-  - python=3.9
+  - python =3.10
   - qt
   - qtpy
-  - recommonmark
   - reproject
-  - scipy
   - setuptools
   - sphinx
   - sphinx-automodapi
-  - widgetsnbextension


### PR DESCRIPTION
### Overview

Previous RTD build attempt failed due to the Conda process taking too much memory! I have tried to turn on RTD builds during pull requests, so hopefully we can work on fixing this without having to merge to the main branch to test each change.