### PR TITLE
Add kernel data relay to Jupyter-related install options

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -147,10 +147,15 @@ setup_args = dict(
             'PyQt6;python_version>="3"',
             'PyQt6-WebEngine;python_version>="3"',
         ],
+        "notebook": [
+            "wwt_kernel_data_relay",
+            "notebook",
+        ],
         "lab": [
             "jupyterlab",
             "nbclassic",
             "notebook",
+            "wwt_kernel_data_relay",
         ],
     },
     entry_points={},


### PR DESCRIPTION
Since the kernel data relay is needed for using pywwt with Jupyter, I think we should include this as a dependency in Jupyter-related install options. The fact that it's not included can cause issues for downstream clients (see e.g. https://github.com/glue-viz/glue-wwt/issues/101).