### PR TITLE
Make qtpy dependency optional

### DIFF
--- a/ci/azure-build-and-test.yml
+++ b/ci/azure-build-and-test.yml
@@ -199,7 +199,7 @@ jobs:
       set -x
       \conda install -y pytest-cov pytest-remotedata pytest-timeout
       python setup.py build
-      pytest -v -s pywwt -p no:warnings --timeout=180 --timeout_method=thread --cov-report=xml --cov=pywwt
+      pytest -v -s pywwt -p no:warnings --timeout=1800 --timeout_method=thread --cov-report=xml --cov=pywwt
     displayName: Test with coverage
 
   - bash: bash <(curl -s https://codecov.io/bash)

--- a/setup.py
+++ b/setup.py
@@ -117,7 +117,6 @@ setup_args = dict(
         "numpy>=1.9",
         "python-dateutil",
         "pytz",
-        "qtpy",
         "reproject>=0.8",
         "requests",
         "toasty>=0.18",
@@ -142,10 +141,12 @@ setup_args = dict(
         "qt": [
             'PyQt5;python_version>="3"',
             'PyQtWebEngine;python_version>="3"',
+            "qtpy",
         ],
         "qt6": [
             'PyQt6;python_version>="3"',
             'PyQt6-WebEngine;python_version>="3"',
+            "qtpy",
         ],
         "notebook": [
             "wwt_kernel_data_relay",


### PR DESCRIPTION
Downstream in `glue-wwt` we're trying to make `qtpy` be an optional dependency (https://github.com/glue-viz/glue-wwt/issues/111) so that it doesn't need to be installed to use the WWT Jupyter viewer. To help make that possible, this PR makes `qtpy` an optional dependency of `pywwt`, moving it to the `qt` and `qt6` install options.

The [documentation](https://github.com/WorldWideTelescope/pywwt/blob/master/docs/installation.rst?plain=1#L221) already makes it sound like `qtpy` is an optional dependency, so I don't think it needs to be changed at all?