### PR TITLE
Replace pipes with shlex in setupbase

### DIFF
--- a/setupbase.py
+++ b/setupbase.py
@@ -14,7 +14,6 @@ from os.path import join as pjoin
 import io
 import os
 import functools
-import pipes
 import re
 import shlex
 import subprocess
@@ -50,7 +49,7 @@ if sys.platform == "win32":
 else:
 
     def list2cmdline(cmd_list):
-        return " ".join(map(pipes.quote, cmd_list))
+        return " ".join(map(shlex.quote, cmd_list))
 
 
 __version__ = "0.2.0"


### PR DESCRIPTION
We currently have a reference to the `pipes` package in our `setupbase` utilities, has been deprecated since Python 3.11 and has now been removed in 3.13. Our only need for `pipes` is a single use of `pipes.quote`, which was [already being imported from `shlex`](https://github.com/python/cpython/blob/3.12/Lib/pipes.py#L66), so this PR replaces it with `shlex.quote`.

FWIW, I noticed this issue in a downstream `glue-wwt` [CI job](https://github.com/glue-viz/glue-wwt/actions/runs/13123865470/job/37950729027).