### PR TITLE
Update roles for links to other docs pages

### DIFF
--- a/docs/controlling.rst
+++ b/docs/controlling.rst
@@ -1,7 +1,7 @@
 Controlling WWT from Python
 ===========================
 
-Once you've `opened up your WWT viewer <opening>`_, you can control nearly every
+Once you've :doc:`opened up your WWT viewer <opening>`, you can control nearly every
 aspect of it programmatically with pywwt.
 
 .. toctree::

--- a/docs/jupyter.rst
+++ b/docs/jupyter.rst
@@ -1,8 +1,8 @@
 WWT's Jupyter widget
 ====================
 
-While we recommend `combining WWT with JupyterLab using the "research app"
-<jupyterlab>`_, pywwt also provides a traditional `Jupyter widget
+While we recommend :doc:`combining WWT with JupyterLab using the "research app"
+<jupyterlab>`, pywwt also provides a traditional `Jupyter widget
 <https://ipywidgets.readthedocs.io/>`__ that can be embedded directly in your
 Python notebooks.
 

--- a/docs/jupyterlab.rst
+++ b/docs/jupyterlab.rst
@@ -5,8 +5,8 @@ To use WWT in an interactive Python environment, we *strongly* recommend
 combining it with `JupyterLab <https://jupyterlab.readthedocs.io/>`_ using WWT's
 "research app". It’s worth noting that the JupyterLab web application is a
 separate thing than just “Jupyter,” the lower-level system upon which it is
-built. `Learn how to set up pywwt's JupyerLab integration JupyterLab here
-<installation>`_.
+built. :doc:`Learn how to set up pywwt's JupyerLab integration JupyterLab here
+<installation>`.
 
 Once the ingration is set up, then the next time you start up JupyterLab the
 “Launcher” display should now contain a WorldWide Telescope icon:

--- a/docs/qt.rst
+++ b/docs/qt.rst
@@ -1,8 +1,8 @@
 WWT in Qt applications
 ======================
 
-Along with the web-based `JupyterLab <jupyterlab>`_ or `Jupyter widget
-<jupyter>`_ options, you can also use WWT in Python-based desktop applications
+Along with the web-based :doc:`JupyterLab <jupyterlab>` or :doc:`Jupyter widget
+<jupyter>` options, you can also use WWT in Python-based desktop applications
 using its support for the `Qt <https://www.qt.io/>`__ graphical toolkit.
 
 IPython


### PR DESCRIPTION
This PR fixes #383 by updating the offending links to use the `:doc:` role. This is similar to what we already do e.g. [here](https://github.com/WorldWideTelescope/pywwt/blob/master/docs/qt.rst?plain=1#L53). The links that we're changing here just have text different than the page name.

What I don't know is whether these links have never worked, or whether this is due to some change in Sphinx. Pinging @pkgw in case he has any thoughts.