### PR TITLE
Try and fix ctypes DLL issue in Windows CI

### DIFF
--- a/ci/azure-build-and-test.yml
+++ b/ci/azure-build-and-test.yml
@@ -26,7 +26,7 @@ parameters:
       PYTHON_SERIES: "3.10"
 
   - name: windows_310
-    vmImage: windows-2022
+    vmImage: windows-2025
     vars:
       PYTHON_SERIES: "3.10"
 

--- a/ci/azure-job-setup.yml
+++ b/ci/azure-job-setup.yml
@@ -108,6 +108,7 @@ steps:
       conda config --set channel_priority strict
       if [[ $AGENT_OS == Windows_NT ]] ; then
         conda install -y libffi --channel conda-forge
+        conda install -y python
       fi
       conda update -y --all
     displayName: Activate conda-forge

--- a/ci/azure-job-setup.yml
+++ b/ci/azure-job-setup.yml
@@ -107,7 +107,7 @@ steps:
       conda config --add channels conda-forge
       conda config --set channel_priority strict
       if [[ $AGENT_OS == Windows_NT ]] ; then
-        conda install libffi --channel conda-forge
+        conda install -y libffi --channel conda-forge
       fi
       conda update -y --all
     displayName: Activate conda-forge

--- a/ci/azure-job-setup.yml
+++ b/ci/azure-job-setup.yml
@@ -87,6 +87,17 @@ steps:
         rm -f miniforge.sh
         condabin="$CONDA/bin"
       elif [[ $AGENT_OS == Windows_NT ]] ; then
+        curl -L -o miniconda.exe https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe
+        ./miniconda.exe /InstallationType=JustMe /RegisterPython=0 /AddToPath=0 /S /D=$HOME/miniconda
+    
+        # Add conda to PATH
+        export PATH="$HOME/miniconda/Scripts:$HOME/miniconda:$PATH"
+
+        # Set Conda location
+        CONDA = $HOME/miniconda
+        
+        # Activate Conda
+        source "$HOME/miniconda/etc/profile.d/conda.sh"
         CONDA=$(echo "$CONDA" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
         condabin="$CONDA/Scripts"
       else

--- a/ci/azure-job-setup.yml
+++ b/ci/azure-job-setup.yml
@@ -106,6 +106,7 @@ steps:
       export CONDA_PLUGINS_AUTO_ACCEPT_TOS=yes  # See https://www.anaconda.com/docs/getting-started/tos-plugin#troubleshooting
       conda config --add channels conda-forge
       conda config --set channel_priority strict
+      conda install libffi --channel conda-forge
       conda update -y --all
     displayName: Activate conda-forge
 

--- a/ci/azure-job-setup.yml
+++ b/ci/azure-job-setup.yml
@@ -87,7 +87,7 @@ steps:
         rm -f miniforge.sh
         condabin="$CONDA/bin"
       elif [[ $AGENT_OS == Windows_NT ]] ; then
-        curl -L -o miniconda.exe https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe
+        curl -o miniconda.exe https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe
         ./miniconda.exe /InstallationType=JustMe /RegisterPython=0 /AddToPath=0 /S /D=$HOME/miniconda
     
         # Add conda to PATH

--- a/ci/azure-job-setup.yml
+++ b/ci/azure-job-setup.yml
@@ -106,7 +106,9 @@ steps:
       export CONDA_PLUGINS_AUTO_ACCEPT_TOS=yes  # See https://www.anaconda.com/docs/getting-started/tos-plugin#troubleshooting
       conda config --add channels conda-forge
       conda config --set channel_priority strict
-      conda install libffi --channel conda-forge
+      if [[ $AGENT_OS == Windows_NT ]] ; then
+        conda install libffi --channel conda-forge
+      fi
       conda update -y --all
     displayName: Activate conda-forge
 

--- a/ci/azure-job-setup.yml
+++ b/ci/azure-job-setup.yml
@@ -104,7 +104,7 @@ steps:
         
         # Activate Conda
         source "$HOME/miniconda/etc/profile.d/conda.sh"
-        CONDA=$(echo "$CONDA" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        $CONDA=$(echo "$CONDA" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
         condabin="$CONDA/Scripts"
       else
         condabin="$CONDA/bin"

--- a/ci/azure-job-setup.yml
+++ b/ci/azure-job-setup.yml
@@ -76,6 +76,14 @@ steps:
     inputs:
       versionSpec: '>=12'
 
+  - powershell: |
+      $url = "https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe"
+      $out = "$env:USERPROFILE\miniconda.exe"
+      Invoke-WebRequest -Uri $url -OutFile $out -UseBasicParsing
+      Start-Process -FilePath $out -ArgumentList "/InstallationType=JustMe", "/RegisterPython=0", "/AddToPath=0", "/S", "/D=$env:USERPROFILE\Miniconda3" -Wait
+    displayName: 'Download & Install Miniconda (PowerShell)'
+    condition: eq( variables['Agent.OS'], 'Windows_NT')
+
   - bash: |
       set -euo pipefail
 
@@ -87,7 +95,6 @@ steps:
         rm -f miniforge.sh
         condabin="$CONDA/bin"
       elif [[ $AGENT_OS == Windows_NT ]] ; then
-        curl -o miniconda.exe https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe
         ./miniconda.exe /InstallationType=JustMe /RegisterPython=0 /AddToPath=0 /S /D=$HOME/miniconda
     
         # Add conda to PATH

--- a/ci/azure-job-setup.yml
+++ b/ci/azure-job-setup.yml
@@ -78,7 +78,7 @@ steps:
 
   - powershell: |
       $url = "https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe"
-      $out = "$env:USERPROFILE\miniconda.exe"
+      $out = "miniconda.exe"
       Invoke-WebRequest -Uri $url -OutFile $out -UseBasicParsing
       Start-Process -FilePath $out -ArgumentList "/InstallationType=JustMe", "/RegisterPython=0", "/AddToPath=0", "/S", "/D=$env:USERPROFILE\Miniconda3" -Wait
     displayName: 'Download & Install Miniconda (PowerShell)'

--- a/ci/azure-job-setup.yml
+++ b/ci/azure-job-setup.yml
@@ -81,6 +81,7 @@ steps:
       $out = "miniconda.exe"
       Invoke-WebRequest -Uri $url -OutFile $out -UseBasicParsing
       Start-Process -FilePath $out -ArgumentList "/InstallationType=JustMe", "/RegisterPython=0", "/AddToPath=0", "/S", "/D=$env:USERPROFILE\Miniconda3" -Wait
+      ./miniconda.exe /InstallationType=JustMe /RegisterPython=0 /AddToPath=0 /S /D=$HOME/miniconda
     displayName: 'Download & Install Miniconda (PowerShell)'
     condition: eq( variables['Agent.OS'], 'Windows_NT')
 
@@ -95,8 +96,6 @@ steps:
         rm -f miniforge.sh
         condabin="$CONDA/bin"
       elif [[ $AGENT_OS == Windows_NT ]] ; then
-        ./miniconda.exe /InstallationType=JustMe /RegisterPython=0 /AddToPath=0 /S /D=$HOME/miniconda
-    
         # Add conda to PATH
         export PATH="$HOME/miniconda/Scripts:$HOME/miniconda:$PATH"
 

--- a/ci/azure-job-setup.yml
+++ b/ci/azure-job-setup.yml
@@ -100,18 +100,20 @@ steps:
         export PATH="$HOME/miniconda/Scripts:$HOME/miniconda:$PATH"
 
         # Set Conda location
-        $CONDA = $HOME/miniconda
+        CONDA=$HOME/miniconda
         
         # Activate Conda
         source "$HOME/miniconda/etc/profile.d/conda.sh"
-        $CONDA=$(echo "$CONDA" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        CONDA=$(echo "$CONDA" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
         condabin="$CONDA/Scripts"
+        condaex="$condabin/conda.exe"
       else
         condabin="$CONDA/bin"
+        condaex="$condabin/conda"
       fi
 
       cat >activate-conda.sh <<EOF
-      eval "\$($condabin/conda shell.bash hook)"
+      eval "\$($condaex shell.bash hook)"
       conda activate
       EOF
     displayName: Set up Conda activation

--- a/ci/azure-job-setup.yml
+++ b/ci/azure-job-setup.yml
@@ -100,7 +100,7 @@ steps:
         export PATH="$HOME/miniconda/Scripts:$HOME/miniconda:$PATH"
 
         # Set Conda location
-        CONDA = $HOME/miniconda
+        $CONDA = $HOME/miniconda
         
         # Activate Conda
         source "$HOME/miniconda/etc/profile.d/conda.sh"

--- a/ci/azure-job-setup.yml
+++ b/ci/azure-job-setup.yml
@@ -81,7 +81,7 @@ steps:
       $out = "miniconda.exe"
       Invoke-WebRequest -Uri $url -OutFile $out -UseBasicParsing
       Start-Process -FilePath $out -ArgumentList "/InstallationType=JustMe", "/RegisterPython=0", "/AddToPath=0", "/S", "/D=$env:USERPROFILE\Miniconda3" -Wait
-      ./miniconda.exe /InstallationType=JustMe /RegisterPython=0 /AddToPath=0 /S /D=$HOME/miniconda
+      ./miniconda.exe /InstallationType=JustMe /RegisterPython=0 /AddToPath=0 /S /D=$HOME\miniconda
     displayName: 'Download & Install Miniconda (PowerShell)'
     condition: eq( variables['Agent.OS'], 'Windows_NT')
 


### PR DESCRIPTION
The Windows CI is failing due to some issue with importing `_ctypes`  when reactivating the conda environment. This PR is an attempt to fix that.

From what I've gathered from reading online, it sounds like this might be an issue with the `libffi` DLL being missing. Let's see if that's the case.