### PR TITLE
Use np.str_ for numpy 2 compatibility

### DIFF
--- a/pywwt/layers.py
+++ b/pywwt/layers.py
@@ -127,7 +127,7 @@ if sys.version_info[0] == 2:
     NP_STR_TYPE = np.string_
 else:
     STR_TYPE = str
-    NP_STR_TYPE = np.unicode_
+    NP_STR_TYPE = np.str_
 
 # The following are columns that we add dynamically and internally, so we need
 # to make sure they have unique names that won't clash with existing columns


### PR DESCRIPTION
The Read the Docs job is failing because we use `np.unicode_`, which no longer exists in numpy 2. This PR updates to use `np.str_`, which was equivalent to `np.unicode_` in numpy 1.x and still exists in numpy 2.